### PR TITLE
Allow epoch timestamp

### DIFF
--- a/src/dali/abstract_transaction.py
+++ b/src/dali/abstract_transaction.py
@@ -73,7 +73,10 @@ class AbstractTransaction:
     def _validate_timestamp_field(cls, name: str, value: str, raw_data: str) -> StringAndDatetime:
         value = cls._validate_string_field(name, value, raw_data, disallow_empty=True, disallow_unknown=True)
         try:
-            result: datetime = parse(value)
+            if value.isdigit():
+                result: datetime = datetime.fromtimestamp(value)
+            else:
+                result: datetime = parse(value)
         except Exception as exc:
             raise Exception(f"Internal error parsing {name} as datetime: {value}\n{raw_data}\n{str(exc)}") from exc
         if result.tzinfo is None:


### PR DESCRIPTION
For Binance.com (and possibly other exchanges) the rest API returns epoch time in milliseconds. It seems a little silly to format the epoch time only to be parsed later. Is it possible to check if the timestamp is an epoch timestamp and if so, just use that to create the timestamp_value datetime variable.