### PR TITLE
Remove unneccessary 'pylint: disable=no-self-use' after upgrading pyl…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ dev =
     mypy==0.942
     pep8
     pre-commit
-    pylint
+    pylint>=2.14.0
     pytest
     pytest-mock
     rope

--- a/src/dali/abstract_input_plugin.py
+++ b/src/dali/abstract_input_plugin.py
@@ -33,7 +33,6 @@ class AbstractInputPlugin:
         self.__account_holder: str = account_holder
         self.__native_fiat: Optional[str] = native_fiat
 
-    # pylint: disable=no-self-use
     def cache_key(self) -> Optional[str]:
         return None
 

--- a/src/dali/plugin/pair_converter/historic_crypto.py
+++ b/src/dali/plugin/pair_converter/historic_crypto.py
@@ -16,16 +16,13 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from Historic_Crypto import HistoricalData
-
 from rp2.rp2_decimal import RP2Decimal
 
-from dali.historical_bar import HistoricalBar
 from dali.abstract_pair_converter_plugin import AbstractPairConverterPlugin
+from dali.historical_bar import HistoricalBar
 
 
 class PairConverterPlugin(AbstractPairConverterPlugin):
-
-    # pylint: disable=no-self-use
     def name(self) -> str:
         return "Historic-Crypto"
 

--- a/tests/test_plugin_coinbase.py
+++ b/tests/test_plugin_coinbase.py
@@ -22,8 +22,6 @@ from dali.plugin.input.rest.coinbase import InputPlugin
 
 
 class TestTrade:
-
-    # pylint: disable=no-self-use
     def test_eth2_stake(self, mocker: Any) -> None:
         plugin = InputPlugin(
             account_holder="tester",

--- a/tests/test_plugin_coinbase_pro.py
+++ b/tests/test_plugin_coinbase_pro.py
@@ -20,8 +20,6 @@ from dali.plugin.input.rest.coinbase_pro import InputPlugin
 
 
 class TestSwapFill:
-
-    # pylint: disable=no-self-use
     def test_buy_side(self, mocker: Any) -> None:
         plugin = InputPlugin(
             account_holder="tester",

--- a/tests/test_plugin_historic_crypto.py
+++ b/tests/test_plugin_historic_crypto.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta, timezone
 import os
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from rp2.rp2_decimal import RP2Decimal
@@ -23,7 +23,6 @@ from dali.cache import CACHE_DIR, load_from_cache
 from dali.configuration import Keyword
 from dali.historical_bar import HistoricalBar
 from dali.plugin.pair_converter.historic_crypto import PairConverterPlugin
-
 
 BAR_DURATION: timedelta = timedelta(seconds=60)
 BAR_TIMESTAMP: datetime = datetime(2020, 6, 1, 0, 0).replace(tzinfo=timezone.utc)
@@ -35,8 +34,6 @@ BAR_VOLUME: RP2Decimal = RP2Decimal("1")
 
 
 class TestHistoricCryptoPlugin:
-
-    # pylint: disable=no-self-use
     def test_historical_prices(self, mocker: Any) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
         cache_path = os.path.join(CACHE_DIR, plugin.cache_key())
@@ -91,7 +88,6 @@ class TestHistoricCryptoPlugin:
         assert data.close == BAR_CLOSE
         assert data.volume == BAR_VOLUME
 
-    # pylint: disable=no-self-use
     def test_missing_historical_prices(self, mocker: Any) -> None:
         plugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
         timestamp = datetime(2020, 6, 1, 0, 0)


### PR DESCRIPTION
Remove unneccessary 'pylint: disable=no-self-use' after upgrading pylint >= 2.14.

Two of the files modified by this change were not properly formatted with isort in DaLi main branch. Those files are modified by isort as part of this PR in addition to the pylint changes:

- pair_converter\historic_crypto.py
- test_plugin_historic_crypto.py