### PR TITLE
Throw an exception when a manual csv does not have enough columns

### DIFF
--- a/src/dali/plugin/input/csv/manual.py
+++ b/src/dali/plugin/input/csv/manual.py
@@ -114,7 +114,7 @@ class InputPlugin(AbstractInputPlugin):
             for line in lines:
                 raw_data: str = ",".join(line).strip()
                 if not header_found:
-                    # let's let the user know they don't have enough columns
+                    # let user know there is not enough columns
                     if len(line) - 1 < self.__IN_NOTES_INDEX:
                         raise ValueError(f"Not enough columns: the CSV must contain {self.__IN_NOTES_INDEX} columns.")
 
@@ -161,7 +161,12 @@ class InputPlugin(AbstractInputPlugin):
             header_found: bool = False
             for line in lines:
                 raw_data: str = ",".join(line).strip()
+
                 if not header_found:
+                    # let user know there is not enough columns
+                    if len(line) - 1 < self.__IN_NOTES_INDEX:
+                        raise ValueError(f"Not enough columns: the CSV must contain {self.__IN_NOTES_INDEX} columns.")
+
                     # Skip header line
                     header_found = True
                     self.__logger.debug("Header: %s", ";".join(line))
@@ -206,6 +211,10 @@ class InputPlugin(AbstractInputPlugin):
             for line in lines:
                 raw_data: str = ",".join(line).strip()
                 if not header_found:
+                    # let user know there is not enough columns
+                    if len(line) - 1 < self.__IN_NOTES_INDEX:
+                        raise ValueError(f"Not enough columns: the CSV must contain {self.__IN_NOTES_INDEX} columns.")
+
                     # Skip header line
                     header_found = True
                     self.__logger.debug("Header: %s", ";".join(line))

--- a/src/dali/plugin/input/csv/manual.py
+++ b/src/dali/plugin/input/csv/manual.py
@@ -116,7 +116,7 @@ class InputPlugin(AbstractInputPlugin):
                 if not header_found:
                     # let's let the user know they don't have enough columns
                     if len(line) - 1 < self.__IN_NOTES_INDEX:
-                        raise ValueError("Not enough columns, the CSV must contain all columns, even optional columns.")
+                        raise ValueError(f"Not enough columns: the CSV must contain {self.__IN_NOTES_INDEX} columns.")
 
                     # Skip header line
                     header_found = True

--- a/src/dali/plugin/input/csv/manual.py
+++ b/src/dali/plugin/input/csv/manual.py
@@ -116,7 +116,7 @@ class InputPlugin(AbstractInputPlugin):
                 if not header_found:
                     # let user know there is not enough columns
                     if len(line) - 1 < self.__IN_NOTES_INDEX:
-                        raise ValueError(f"Not enough columns: the CSV must contain {self.__IN_NOTES_INDEX} columns.")
+                        raise ValueError(f"Not enough columns: the {self.__in_csv_file} CSV must contain {self.__IN_NOTES_INDEX} columns.")
 
                     # Skip header line
                     header_found = True

--- a/src/dali/plugin/input/csv/manual.py
+++ b/src/dali/plugin/input/csv/manual.py
@@ -212,8 +212,8 @@ class InputPlugin(AbstractInputPlugin):
                 raw_data: str = ",".join(line).strip()
                 if not header_found:
                     # let user know there is not enough columns
-                    if len(line) - 1 < self.__IN_NOTES_INDEX:
-                        raise ValueError(f"Not enough columns: the CSV must contain {self.__IN_NOTES_INDEX} columns.")
+                    if len(line) - 1 < self.__INTRA_NOTES_INDEX:
+                        raise ValueError(f"Not enough columns: the {self.__intra_csv_file} CSV must contain {self.__INTRA_NOTES_INDEX} columns.")
 
                     # Skip header line
                     header_found = True

--- a/src/dali/plugin/input/csv/manual.py
+++ b/src/dali/plugin/input/csv/manual.py
@@ -164,8 +164,8 @@ class InputPlugin(AbstractInputPlugin):
 
                 if not header_found:
                     # let user know there is not enough columns
-                    if len(line) - 1 < self.__IN_NOTES_INDEX:
-                        raise ValueError(f"Not enough columns: the CSV must contain {self.__IN_NOTES_INDEX} columns.")
+                    if len(line) - 1 < self.__OUT_NOTES_INDEX:
+                        raise ValueError(f"Not enough columns: the {self.__out_csv_file} CSV must contain {self.__OUT_NOTES_INDEX} columns.")
 
                     # Skip header line
                     header_found = True

--- a/src/dali/plugin/input/csv/manual.py
+++ b/src/dali/plugin/input/csv/manual.py
@@ -114,6 +114,10 @@ class InputPlugin(AbstractInputPlugin):
             for line in lines:
                 raw_data: str = ",".join(line).strip()
                 if not header_found:
+                    # let's let the user know they don't have enough columns
+                    if len(line) - 1 < self.__IN_NOTES_INDEX:
+                        raise ValueError("Not enough columns, the CSV must contain all columns, even optional columns.")
+
                     # Skip header line
                     header_found = True
                     self.__logger.debug("Header: %s", ";".join(line))


### PR DESCRIPTION
I interpretted the "optional" columns to be optional within the CSV structure. This change
provides clear feedback to users if they do not include enough columns.
