### PR TITLE
Don't prevent empty on out transactions

### DIFF
--- a/src/dali/out_transaction.py
+++ b/src/dali/out_transaction.py
@@ -39,7 +39,7 @@ class OutTransaction(AbstractTransaction):
         transaction_type: str,
         spot_price: str,
         crypto_out_no_fee: str,
-        crypto_fee: str,
+        crypto_fee: Optional[str] = None,
         crypto_out_with_fee: Optional[str] = None,
         fiat_out_no_fee: Optional[str] = None,
         fiat_fee: Optional[str] = None,
@@ -123,7 +123,7 @@ class OutTransaction(AbstractTransaction):
         return self.__crypto_out_no_fee
 
     @property
-    def crypto_fee(self) -> str:
+    def crypto_fee(self) -> Optional[str]:
         return self.__crypto_fee
 
     @property

--- a/src/dali/out_transaction.py
+++ b/src/dali/out_transaction.py
@@ -65,7 +65,9 @@ class OutTransaction(AbstractTransaction):
         self.__crypto_out_no_fee: str = self._validate_numeric_field(
             Keyword.CRYPTO_OUT_NO_FEE.value, crypto_out_no_fee, raw_data, disallow_empty=True, disallow_unknown=True
         )
-        self.__crypto_fee: str = self._validate_numeric_field(Keyword.CRYPTO_FEE.value, crypto_fee, raw_data, disallow_empty=True, disallow_unknown=True)
+        self.__crypto_fee: Optional[str] = self._validate_optional_numeric_field(
+            Keyword.CRYPTO_FEE.value, crypto_fee, raw_data, disallow_empty=False, disallow_unknown=True
+        )
         self.__crypto_out_with_fee: Optional[str] = self._validate_optional_numeric_field(
             Keyword.CRYPTO_OUT_WITH_FEE.value, crypto_out_with_fee, raw_data, disallow_empty=False, disallow_unknown=True
         )

--- a/src/dali/transaction_resolver.py
+++ b/src/dali/transaction_resolver.py
@@ -417,11 +417,6 @@ def _apply_transaction_hint(
                 notes=notes,
             )
         elif isinstance(transaction, OutTransaction):
-            if is_unknown(transaction.crypto_out_no_fee) or is_unknown(transaction.crypto_fee):
-                raise RP2ValueError(
-                    f"Invalid conversion {Keyword.INTRA.value}->{Keyword.OUT.value}: "
-                    f"{Keyword.CRYPTO_OUT_NO_FEE.value}/{Keyword.CRYPTO_FEE.value} cannot be unknown: {transaction}"
-                )
             result = IntraTransaction(
                 plugin=transaction.plugin,
                 unique_id=transaction.unique_id,

--- a/tests/test_plugin_coinbase.py
+++ b/tests/test_plugin_coinbase.py
@@ -155,7 +155,7 @@ class TestTrade:
         assert out_transaction.transaction_type == "Sell"
         assert RP2Decimal(out_transaction.spot_price) == RP2Decimal("3E+3")
         assert RP2Decimal(out_transaction.crypto_out_no_fee) == RP2Decimal("0.10000000")
-        assert RP2Decimal(out_transaction.crypto_fee) == RP2Decimal("0.000")
+        assert in_transaction.crypto_fee is None
         assert RP2Decimal(out_transaction.crypto_out_with_fee) == RP2Decimal("0.10000000")  # type: ignore
         assert RP2Decimal(out_transaction.fiat_out_no_fee) == RP2Decimal("300.00")  # type: ignore
         assert RP2Decimal(out_transaction.fiat_fee) == RP2Decimal("0")  # type: ignore


### PR DESCRIPTION
They are not preventing on in transactions. I didn't see any reason why we shouldn't use the same field requirements.
