### PR TITLE
Pre commit formatting fixes

### DIFF
--- a/src/dali/dali_main.py
+++ b/src/dali/dali_main.py
@@ -44,7 +44,9 @@ from dali.intra_transaction import IntraTransaction
 from dali.logger import LOGGER
 from dali.ods_generator import generate_input_file
 from dali.out_transaction import OutTransaction
-from dali.plugin.pair_converter.historic_crypto import PairConverterPlugin as HistoricCryptoPairConverterPlugin
+from dali.plugin.pair_converter.historic_crypto import (
+    PairConverterPlugin as HistoricCryptoPairConverterPlugin,
+)
 from dali.transaction_resolver import resolve_transactions
 
 _VERSION: str = "0.4.12"

--- a/src/dali/historical_bar.py
+++ b/src/dali/historical_bar.py
@@ -16,8 +16,8 @@
 from datetime import datetime, timedelta
 from typing import NamedTuple, cast
 
-from rp2.rp2_error import RP2ValueError
 from rp2.rp2_decimal import RP2Decimal
+from rp2.rp2_error import RP2ValueError
 
 from dali.configuration import Keyword
 

--- a/src/dali/plugin/country/us.py
+++ b/src/dali/plugin/country/us.py
@@ -14,6 +14,7 @@
 
 
 from rp2.plugin.country.us import US
+
 from dali.dali_main import dali_main
 
 

--- a/tests/test_historical_bar.py
+++ b/tests/test_historical_bar.py
@@ -17,7 +17,7 @@ from dataclasses import FrozenInstanceError
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from rp2.rp2_decimal import RP2Decimal, ZERO
+from rp2.rp2_decimal import ZERO, RP2Decimal
 from rp2.rp2_error import RP2ValueError
 
 from dali.configuration import Keyword


### PR DESCRIPTION
These are changes caused by: pre-commit run --all-files

Updating the repo with latest formatting changes will make it easier for devs
to run this locally.
