### PR TITLE
Rename Exceptions to RP2RuntimeErrors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     python-dateutil>=2.8.2
     pytz>=2021.3
     requests>=2.26.0
-    rp2>=1.4.0
+    rp2>=1.4.1
 
 [options.extras_require]
 dev =

--- a/src/dali/abstract_ccxt_input_plugin.py
+++ b/src/dali/abstract_ccxt_input_plugin.py
@@ -34,6 +34,7 @@ from ccxt import (
 )
 from rp2.logger import create_logger
 from rp2.rp2_decimal import ZERO, RP2Decimal
+from rp2.rp2_error import RP2RuntimeError
 
 from dali.abstract_input_plugin import AbstractInputPlugin
 from dali.abstract_transaction import AbstractTransaction
@@ -208,7 +209,7 @@ class AbstractCcxtInputPlugin(AbstractInputPlugin):
         pagination_detail_set: Optional[AbstractPaginationDetailSet] = self._get_process_deposits_pagination_detail_set()
         # Strip optionality
         if not pagination_detail_set:
-            raise Exception("No Pagination Details for Deposits")
+            raise RP2RuntimeError("No Pagination Details for Deposits")
 
         has_pagination_detail_set: AbstractPaginationDetailSet = pagination_detail_set
 
@@ -304,7 +305,7 @@ class AbstractCcxtInputPlugin(AbstractInputPlugin):
         pagination_detail_set: Optional[AbstractPaginationDetailSet] = self._get_process_trades_pagination_detail_set()
         # Strip optionality
         if not pagination_detail_set:
-            raise Exception("No pagination details for trades.")
+            raise RP2RuntimeError("No pagination details for trades.")
 
         has_pagination_detail_set: AbstractPaginationDetailSet = pagination_detail_set
 
@@ -373,7 +374,7 @@ class AbstractCcxtInputPlugin(AbstractInputPlugin):
         pagination_detail_set: Optional[AbstractPaginationDetailSet] = self._get_process_withdrawals_pagination_detail_set()
         # Strip optionality
         if not pagination_detail_set:
-            raise Exception("No pagination details for withdrawals.")
+            raise RP2RuntimeError("No pagination details for withdrawals.")
 
         has_pagination_detail_set: AbstractPaginationDetailSet = pagination_detail_set
 
@@ -465,7 +466,7 @@ class AbstractCcxtInputPlugin(AbstractInputPlugin):
                 request_count += 1
                 if request_count > 9:
                     self.__logger.info("Maximum number of retries reached.")
-                    raise Exception("Server error") from exc_na
+                    raise RP2RuntimeError("Server error") from exc_na
 
                 self.__logger.debug("Server not available. Making attempt #%s of 10 after a ten second delay. Exception - %s", request_count, exc_na)
                 sleep(10)
@@ -500,7 +501,7 @@ class AbstractCcxtInputPlugin(AbstractInputPlugin):
             crypto_in = RP2Decimal(str(transaction[_COST]))
             conversion_info = f"{trade.base_info} -> {trade.quote_info}"
         else:
-            raise Exception(f"Internal error: unrecognized transaction side: {transaction[_SIDE]}")
+            raise RP2RuntimeError(f"Internal error: unrecognized transaction side: {transaction[_SIDE]}")
 
         if fee_asset == in_asset:
             crypto_fee = RP2Decimal(str(transaction[_FEE][_COST]))
@@ -605,7 +606,7 @@ class AbstractCcxtInputPlugin(AbstractInputPlugin):
             crypto_out_no_fee = RP2Decimal(str(transaction[_AMOUNT]))
             conversion_info = f"{trade.base_info} -> {trade.quote_info}"
         else:
-            raise Exception(f"Internal error: unrecognized transaction side: {transaction[_SIDE]}")
+            raise RP2RuntimeError(f"Internal error: unrecognized transaction side: {transaction[_SIDE]}")
 
         if transaction[_FEE][_CURRENCY] == out_asset:
             crypto_fee: RP2Decimal = RP2Decimal(str(transaction[_FEE][_COST]))

--- a/src/dali/abstract_input_plugin.py
+++ b/src/dali/abstract_input_plugin.py
@@ -14,7 +14,7 @@
 
 from typing import List, Optional, cast
 
-from rp2.rp2_error import RP2TypeError
+from rp2.rp2_error import RP2RuntimeError, RP2TypeError
 
 from dali.abstract_transaction import AbstractTransaction
 from dali.cache import load_from_cache, save_to_cache
@@ -42,17 +42,17 @@ class AbstractInputPlugin:
     def load_from_cache(self) -> Optional[List[AbstractTransaction]]:
         cache_key = self.cache_key()  # pylint: disable=assignment-from-none
         if cache_key is None:
-            raise Exception("Plugin doesn't support load cache")
+            raise RP2RuntimeError("Plugin doesn't support load cache")
         if not isinstance(cache_key, str):
-            raise Exception("Plugin cache_key() doesn't return a string")
+            raise RP2RuntimeError("Plugin cache_key() doesn't return a string")
         return cast(Optional[List[AbstractTransaction]], load_from_cache(cache_key))
 
     def save_to_cache(self, transactions: List[AbstractTransaction]) -> None:
         cache_key = self.cache_key()  # pylint: disable=assignment-from-none
         if cache_key is None:
-            raise Exception("Plugin doesn't support load cache")
+            raise RP2RuntimeError("Plugin doesn't support load cache")
         if not isinstance(cache_key, str):
-            raise Exception("Plugin cache_key() doesn't return a string")
+            raise RP2RuntimeError("Plugin cache_key() doesn't return a string")
         save_to_cache(cache_key, transactions)
 
     @property

--- a/src/dali/abstract_pair_converter_plugin.py
+++ b/src/dali/abstract_pair_converter_plugin.py
@@ -21,7 +21,7 @@ from requests.exceptions import ReadTimeout
 from requests.models import Response
 from requests.sessions import Session
 from rp2.rp2_decimal import ZERO, RP2Decimal
-from rp2.rp2_error import RP2TypeError
+from rp2.rp2_error import RP2RuntimeError, RP2TypeError
 
 from dali.cache import load_from_cache, save_to_cache
 from dali.configuration import HISTORICAL_PRICE_KEYWORD_SET
@@ -177,7 +177,7 @@ class AbstractPairConverterPlugin:
 
         except JSONDecodeError as exc:
             LOGGER.info("Fetching of fiat symbols failed. The server might be down. Please try again later.")
-            raise Exception("JSON decode error") from exc
+            raise RP2RuntimeError("JSON decode error") from exc
 
     def _add_fiat_edges_to_graph(self, graph: Dict[str, Dict[str, None]], markets: Dict[str, List[str]]) -> None:
         if not self.__fiat_list:
@@ -259,6 +259,6 @@ class AbstractPairConverterPlugin:
                 if request_count > 4:
                     LOGGER.info("Giving up after 4 tries. Saving to Cache.")
                     self.save_historical_price_cache()
-                    raise Exception("JSON decode error") from exc
+                    raise RP2RuntimeError("JSON decode error") from exc
 
         return result

--- a/src/dali/ccxt_pagination.py
+++ b/src/dali/ccxt_pagination.py
@@ -20,6 +20,8 @@
 from datetime import datetime
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
+from rp2.rp2_error import RP2RuntimeError
+
 _TIMESTAMP: str = "timestamp"
 
 # Time period constants
@@ -104,7 +106,7 @@ class CustomDateBasedPaginationDetailSet(DateBasedPaginationDetailSet):
     def _get_window(self) -> int:
         if self.__window:
             return self.__window
-        raise Exception("No window defined for iterator.")
+        raise RP2RuntimeError("No window defined for iterator.")
 
     def __iter__(self) -> "CustomDateBasedPaginationDetailsIterator":
         return CustomDateBasedPaginationDetailsIterator(
@@ -200,7 +202,7 @@ class DateBasedPaginationDetailsIterator(AbstractPaginationDetailsIterator):
     def _get_end_of_window(self) -> int:
         if self.__window:
             return self.__since + self.__window
-        raise Exception("No window defined for iterator.")
+        raise RP2RuntimeError("No window defined for iterator.")
 
     def __next__(self) -> PaginationDetails:
         while not self._is_end_of_data():

--- a/src/dali/configuration_generator.py
+++ b/src/dali/configuration_generator.py
@@ -16,6 +16,8 @@ from configparser import ConfigParser
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
+from rp2.rp2_error import RP2RuntimeError
+
 from dali.abstract_transaction import AbstractTransaction
 from dali.configuration import Keyword
 from dali.in_transaction import InTransaction
@@ -36,13 +38,13 @@ def generate_configuration_file(
 ) -> Any:
 
     if not isinstance(output_dir_path, str):
-        raise Exception(f"Internal error: parameter output_dir_path is not of type string: {repr(output_dir_path)}")
+        raise RP2RuntimeError(f"Internal error: parameter output_dir_path is not of type string: {repr(output_dir_path)}")
     if not isinstance(output_file_prefix, str):
-        raise Exception(f"Internal error: parameter output_file_prefix is not of type string: {repr(output_file_prefix)}")
+        raise RP2RuntimeError(f"Internal error: parameter output_file_prefix is not of type string: {repr(output_file_prefix)}")
     if not isinstance(output_file_name, str):
-        raise Exception(f"Internal error: parameter output_file_name is not of type string: {repr(output_file_name)}")
+        raise RP2RuntimeError(f"Internal error: parameter output_file_name is not of type string: {repr(output_file_name)}")
     if not isinstance(transactions, List):
-        raise Exception(f"Internal error: parameter transactions is not of type List: {repr(transactions)}")
+        raise RP2RuntimeError(f"Internal error: parameter transactions is not of type List: {repr(transactions)}")
 
     output_file_path: Path = Path(output_dir_path) / Path(f"{output_file_prefix}{output_file_name}")
     if Path(output_file_path).exists():
@@ -68,7 +70,7 @@ def generate_configuration_file(
             exchanges.add(transaction.from_exchange)
             exchanges.add(transaction.to_exchange)
         else:
-            raise Exception(f"Internal error: transaction is not a subclass of AbstractTransaction: {transaction}")
+            raise RP2RuntimeError(f"Internal error: transaction is not a subclass of AbstractTransaction: {transaction}")
         assets.add(transaction.asset)
 
     if Keyword.UNKNOWN.value in assets:

--- a/src/dali/in_transaction.py
+++ b/src/dali/in_transaction.py
@@ -14,6 +14,8 @@
 
 from typing import Callable, Dict, List, Optional, Union
 
+from rp2.rp2_error import RP2RuntimeError
+
 from dali.abstract_transaction import AbstractTransaction
 from dali.configuration import Keyword, is_transaction_type_valid
 
@@ -24,7 +26,7 @@ class InTransaction(AbstractTransaction):
         value = cls._validate_string_field(name, value, raw_data, disallow_empty=True, disallow_unknown=True)
         Keyword.type_check_from_string(value)
         if not is_transaction_type_valid(Keyword.IN.value, value):
-            raise Exception(f"Invalid transaction type {value} for {cls.__name__}")
+            raise RP2RuntimeError(f"Invalid transaction type {value} for {cls.__name__}")
         return value.capitalize()
 
     def __init__(
@@ -77,7 +79,7 @@ class InTransaction(AbstractTransaction):
         )
 
         if self.__crypto_fee is not None and self.__fiat_fee is not None:
-            raise Exception(
+            raise RP2RuntimeError(
                 f"Internal error: both 'crypto_fee' and 'fiat_fee' are defined, instead of only one: their values are {crypto_fee} and {fiat_fee} respectively"
             )
 

--- a/src/dali/intra_transaction.py
+++ b/src/dali/intra_transaction.py
@@ -14,6 +14,8 @@
 
 from typing import Callable, Dict, List, Optional, Union
 
+from rp2.rp2_error import RP2RuntimeError
+
 from dali.abstract_transaction import AbstractTransaction
 from dali.configuration import Keyword, is_transaction_type_valid
 
@@ -24,7 +26,7 @@ class IntraTransaction(AbstractTransaction):
         value = cls._validate_string_field(name, value, raw_data, disallow_empty=True, disallow_unknown=True)
         Keyword.type_check_from_string(value)
         if not is_transaction_type_valid(Keyword.INTRA.value, value):
-            raise Exception(f"Invalid transaction type {value} for {cls.__name__}")
+            raise RP2RuntimeError(f"Invalid transaction type {value} for {cls.__name__}")
         return value.capitalize()
 
     def __init__(

--- a/src/dali/ods_generator.py
+++ b/src/dali/ods_generator.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 import ezodf
-from rp2.rp2_error import RP2TypeError
+from rp2.rp2_error import RP2RuntimeError, RP2TypeError
 
 from dali.abstract_transaction import AbstractTransaction
 from dali.configuration import (
@@ -162,7 +162,7 @@ def generate_input_file(
     row_index: int = 0
     for transaction in transactions:
         if not isinstance(transaction, AbstractTransaction):
-            raise Exception(f"Internal error: Parameter 'transaction' is not a subclass of AbstractTransaction. {transaction}")
+            raise RP2RuntimeError(f"Internal error: Parameter 'transaction' is not a subclass of AbstractTransaction. {transaction}")
         if transaction.asset == global_configuration[Keyword.NATIVE_FIAT.value]:
             continue
         table_type: str = _TRANSACTION_CLASS_TO_TABLE[transaction.__class__]

--- a/src/dali/out_transaction.py
+++ b/src/dali/out_transaction.py
@@ -14,6 +14,8 @@
 
 from typing import Callable, Dict, List, Optional, Union
 
+from rp2.rp2_error import RP2RuntimeError
+
 from dali.abstract_transaction import AbstractTransaction
 from dali.configuration import Keyword, is_transaction_type_valid
 
@@ -24,7 +26,7 @@ class OutTransaction(AbstractTransaction):
         value = cls._validate_string_field(name, value, raw_data, disallow_empty=True, disallow_unknown=True)
         Keyword.type_check_from_string(value)
         if not is_transaction_type_valid(Keyword.OUT.value, value):
-            raise Exception(f"Invalid transaction type {value} for {cls.__name__}")
+            raise RP2RuntimeError(f"Invalid transaction type {value} for {cls.__name__}")
         return value.capitalize()
 
     def __init__(

--- a/src/dali/plugin/input/csv/blockfi.py
+++ b/src/dali/plugin/input/csv/blockfi.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Optional
 
 from rp2.logger import create_logger
 from rp2.rp2_decimal import RP2Decimal
+from rp2.rp2_error import RP2RuntimeError
 
 from dali.abstract_input_plugin import AbstractInputPlugin
 from dali.abstract_transaction import AbstractTransaction
@@ -87,7 +88,7 @@ class InputPlugin(AbstractInputPlugin):
                 self.__logger.debug("Transaction: %s", raw_data)
 
                 if last_withdrawal_fee is not None and line[self.__TYPE_INDEX] != _WITHDRAWAL:
-                    raise Exception(f"Internal error: withdrawal fee {last_withdrawal_fee} is not followed by withdrawal")
+                    raise RP2RuntimeError(f"Internal error: withdrawal fee {last_withdrawal_fee} is not followed by withdrawal")
 
                 transaction_type: str = line[self.__TYPE_INDEX]
                 if transaction_type == _INTEREST_PAYMENT:
@@ -239,7 +240,7 @@ class InputPlugin(AbstractInputPlugin):
 
                 transaction_type: str = line[column_index[_TYPE]]
                 if transaction_type != "Trade":
-                    raise Exception(f"Internal error: unsupported transaction type: {transaction_type}")
+                    raise RP2RuntimeError(f"Internal error: unsupported transaction type: {transaction_type}")
 
                 trade_id: str = line[column_index[_TRADE_ID]]
                 date: str = line[column_index[_DATE]]

--- a/src/dali/plugin/input/rest/binance_com.py
+++ b/src/dali/plugin/input/rest/binance_com.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from ccxt import Exchange, binance
 from rp2.rp2_decimal import ZERO, RP2Decimal
+from rp2.rp2_error import RP2RuntimeError
 
 from dali.abstract_ccxt_input_plugin import (
     AbstractCcxtInputPlugin,
@@ -191,7 +192,7 @@ class InputPlugin(AbstractCcxtInputPlugin):
     def _client(self) -> binance:
         super_client: Exchange = super()._client
         if not isinstance(super_client, binance):
-            raise Exception("Exchange is not instance of class binance.")
+            raise RP2RuntimeError("Exchange is not instance of class binance.")
         return super_client
 
     def _get_algos(self) -> List[str]:
@@ -439,7 +440,7 @@ class InputPlugin(AbstractCcxtInputPlugin):
                         earliest_redemption_timestamp = subscription_time + lockperiod_in_ms
 
                     else:
-                        raise Exception(
+                        raise RP2RuntimeError(
                             f"Internal Error: Principal ({original_principal}) minus paid interest ({RP2Decimal(str(total_interest_earned))}) does not equal"
                             f" returned principal ({RP2Decimal(redemption[_AMOUNT])}) on locked savings position ID - {redemption[_POSITION_ID]}."
                         )
@@ -467,7 +468,7 @@ class InputPlugin(AbstractCcxtInputPlugin):
                         )
 
                     else:
-                        raise Exception(
+                        raise RP2RuntimeError(
                             f"Internal Error: The redemption time ({self._rp2_timestamp_from_ms_epoch(redemption[_TIME])}) is not in the redemption window "
                             f"({self._rp2_timestamp_from_ms_epoch(str(earliest_redemption_timestamp))} + 2 days)."
                         )
@@ -477,7 +478,7 @@ class InputPlugin(AbstractCcxtInputPlugin):
                     self._logger.debug("Locked Savings positionId %s redeemed successfully.", redemption[_POSITION_ID])
 
                 else:
-                    raise Exception(f"Internal Error: Orphaned Redemption. Please open an issue at {self.ISSUES_URL}.")
+                    raise RP2RuntimeError(f"Internal Error: Orphaned Redemption. Please open an issue at {self.ISSUES_URL}.")
 
             # if we returned the limit, we need to roll the window forward to the last time
             if len(locked_redemptions) < _INTEREST_SIZE_LIMIT:
@@ -768,7 +769,7 @@ class InputPlugin(AbstractCcxtInputPlugin):
 
                 first_dribblet = [x for x in dust_trades if x[_DIV_TIME] == dust_trades[0][_DIV_TIME]]
                 if len(first_dribblet) == _DUST_TRADE_RECORD_LIMIT:
-                    raise Exception(
+                    raise RP2RuntimeError(
                         f"Internal error: too many assets dusted at the same time: " f"{self._rp2_timestamp_from_ms_epoch(str(dust_trades[0][_DIV_TIME]))}"
                     )
 

--- a/src/dali/plugin/input/rest/coinbase_pro.py
+++ b/src/dali/plugin/input/rest/coinbase_pro.py
@@ -33,6 +33,7 @@ from requests.models import Response
 from requests.sessions import Session
 from rp2.logger import create_logger
 from rp2.rp2_decimal import ZERO, RP2Decimal
+from rp2.rp2_error import RP2RuntimeError
 
 from dali.abstract_input_plugin import AbstractInputPlugin
 from dali.abstract_transaction import AbstractTransaction, AssetAndUniqueId
@@ -139,7 +140,7 @@ class InputPlugin(AbstractInputPlugin):
         self.__cache_key: str = f"coinbase_pro-{account_holder}"
         self.__thread_count = thread_count if thread_count else self.__DEFAULT_THREAD_COUNT
         if self.__thread_count > self.__MAX_THREAD_COUNT:
-            raise Exception(f"Thread count is {self.__thread_count}: it exceeds the maximum value of {self.__MAX_THREAD_COUNT}")
+            raise RP2RuntimeError(f"Thread count is {self.__thread_count}: it exceeds the maximum value of {self.__MAX_THREAD_COUNT}")
         self.__account_id_2_account: Dict[str, Any] = {}
 
     def cache_key(self) -> Optional[str]:
@@ -372,7 +373,7 @@ class InputPlugin(AbstractInputPlugin):
                 from_currency_size = to_currency_size * RP2Decimal(fill[_PRICE])
                 from_currency_price = usd_volume / from_currency_size
             else:
-                raise Exception(f"Internal error: unsupported fill side {transaction}\n{fill}")
+                raise RP2RuntimeError(f"Internal error: unsupported fill side {transaction}\n{fill}")
             self.__append_transaction(
                 cast(List[AbstractTransaction], out_transaction_list),
                 OutTransaction(
@@ -431,7 +432,7 @@ class InputPlugin(AbstractInputPlugin):
         amount: str = conversion[_AMOUNT]
 
         if not self.is_native_fiat(from_currency) and not self.is_native_fiat(to_currency):
-            raise Exception(f"Internal error: conversion without fiat currency ({from_currency} -> {to_currency}):{transaction}//{conversion}")
+            raise RP2RuntimeError(f"Internal error: conversion without fiat currency ({from_currency} -> {to_currency}):{transaction}//{conversion}")
 
         self.__append_transaction(
             cast(List[AbstractTransaction], out_transaction_list),
@@ -529,4 +530,4 @@ class InputPlugin(AbstractInputPlugin):
 
         # Defensive programming: we shouldn't reach here.
         self.__logger.debug("Reached past raise_for_status() call: %s", json_response["message"])
-        raise Exception(message)
+        raise RP2RuntimeError(message)

--- a/src/dali/plugin/pair_converter/ccxt.py
+++ b/src/dali/plugin/pair_converter/ccxt.py
@@ -32,6 +32,7 @@ from ccxt import (
 )
 from rp2.logger import create_logger
 from rp2.rp2_decimal import RP2Decimal
+from rp2.rp2_error import RP2RuntimeError
 
 from dali.abstract_pair_converter_plugin import (
     AbstractPairConverterPlugin,
@@ -435,7 +436,7 @@ class PairConverterPlugin(AbstractPairConverterPlugin):
                     if request_count > 9:
                         self.__logger.info("Maximum number of retries reached. Saving to cache and exiting.")
                         self.save_historical_price_cache()
-                        raise Exception("Server error") from exc_na
+                        raise RP2RuntimeError("Server error") from exc_na
 
                     self.__logger.debug("Server not available. Making attempt #%s of 10 after a ten second delay. Exception - %s", request_count, exc_na)
                     sleep(10)

--- a/src/dali/plugin/pair_converter/csv/kraken.py
+++ b/src/dali/plugin/pair_converter/csv/kraken.py
@@ -29,6 +29,7 @@ from requests.models import Response
 from requests.sessions import Session
 from rp2.logger import create_logger
 from rp2.rp2_decimal import RP2Decimal
+from rp2.rp2_error import RP2RuntimeError
 
 from dali.historical_bar import HistoricalBar
 
@@ -177,7 +178,7 @@ class Kraken:
                         """,
                             error[_MESSAGE],
                         )
-                        raise Exception("Google Drive not authorized")
+                        raise RP2RuntimeError("Google Drive not authorized")
 
             self.__logger.debug("Retrieved %s from %s", data, response.url)
 
@@ -188,7 +189,7 @@ class Kraken:
 
         except JSONDecodeError as exc:
             self.__logger.debug("Fetching of kraken csv files failed. Try again later.")
-            raise Exception("JSON decode error") from exc
+            raise RP2RuntimeError("JSON decode error") from exc
 
         return file_response.content
 

--- a/tests/test_plugin_coinbase.py
+++ b/tests/test_plugin_coinbase.py
@@ -15,6 +15,7 @@
 from typing import Any, Dict, List
 
 from rp2.rp2_decimal import RP2Decimal
+from rp2.rp2_error import RP2RuntimeError
 
 from dali.in_transaction import InTransaction
 from dali.out_transaction import OutTransaction
@@ -136,7 +137,7 @@ class TestTrade:
                     },
                 ]
 
-            raise Exception("Invalid account id: " + account_id)
+            raise RP2RuntimeError("Invalid account id: " + account_id)
 
         mocker.patch.object(plugin, "_InputPlugin__get_transactions").side_effect = mock_get_transaction
 

--- a/tests/test_plugin_coinbase_pro.py
+++ b/tests/test_plugin_coinbase_pro.py
@@ -14,6 +14,8 @@
 
 from typing import Any, Dict, List
 
+from rp2.rp2_error import RP2RuntimeError
+
 from dali.in_transaction import InTransaction
 from dali.out_transaction import OutTransaction
 from dali.plugin.input.rest.coinbase_pro import InputPlugin
@@ -88,7 +90,7 @@ class TestSwapFill:
                     },
                 ]
 
-            raise Exception("Invalid account id: " + account_id)
+            raise RP2RuntimeError("Invalid account id: " + account_id)
 
         mocker.patch.object(plugin, "_InputPlugin__get_transactions").side_effect = mock_get_transaction
 


### PR DESCRIPTION
This is to address the too-broad exceptions flagged by Pylint.