### PR TITLE
Provide value to log string in dali.plugin.pair_converter.csv.kraken

### DIFF
--- a/src/dali/plugin/pair_converter/csv/kraken.py
+++ b/src/dali/plugin/pair_converter/csv/kraken.py
@@ -352,7 +352,7 @@ class Kraken:
                         )
                         raise RP2RuntimeError("Google Drive key invalid")
             if not data.get(_FILES):
-                self.__logger.debug("The file '%s' was not found on the Kraken Google Drive.")
+                self.__logger.debug("The file '%s' was not found on the Kraken Google Drive.", file_name)
                 return None
 
             self.__logger.debug("Retrieved %s from %s", data, response.url)


### PR DESCRIPTION
Actually include `file_name` in log message indicating file is missing from Kraken Google Drive.