### PR TITLE
Add Optimization to Djikstra

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -473,6 +473,7 @@ historical_price_type = <em>&lt;historical_price_type&gt;</em>
 default_exchange = <em>&lt;default_exchange&gt;</em>
 fiat_priority = <em>&lt;fiat_priority&gt;</em>
 google_api_key = <em>&lt;google_api_key&gt;</em>
+untradeable_assets = <em>&lt;untradeable_assets&gt;</em>
 </pre>
 
 Where:
@@ -480,6 +481,7 @@ Where:
 * `default_exchange` is an optional string for the name of an exchange to use if the exchange listed in a transaction is not currently supported by the CCXT plugin. If no default is set, Kraken(US) is used. If you would like an exchange added please open an issue. The current available exchanges are "Binance.com", "Gate", "Huobi" and "Kraken".
 * `fiat_priority` is an optional list of strings in JSON format (e.g. `["_1stpriority_", "_2ndpriority_"...]`) that ranks the priority of fiat in the routing system. If no `fiat_priority` is given, the default priority is USD, JPY, KRW, EUR, GBP, AUD, which is based on the volume of the fiat market paired with BTC (ie. BTC/USD has the highest worldwide volume, then BTC/JPY, etc.).
 * `google_api_key` is an optional string for the Google API Key that is needed by some CSV readers, most notably the Kraken CSV reader. It is used to download the OHLCV files for a market. No data is ever sent to Google Drive. This is only used to retrieve data. To get a Google API Key, visit the [Google Console Page](https://console.developers.google.com/) and setup a new project. Be sure to enable the Google Drive API by clicking [+ ENABLE APIS AND SERVICES] and selecting the Google Drive API.
+* `untradeable_assets` is a comma separated list of assets that have no market, yet. These are typically assets that are farmed or given away as a part of promotion before a market is available to price them and CCXT can not automatically assign a price. If you get the error "The asset XXX or XXX is missing from graph" and the asset is untradeable, adding the untradeable asset to this list will resolve it.
 
 The CCXT pair converter plugin uses a routing system to find the shortest pricing path between a base asset and a quote asset (what the asset is priced in). It does this by assembling a graph of nodes made out of assets and edges made from markets with a preference for the exchange the asset was purchased on. Fiat exchange rates from the European Central Bank are also added to the graph to allow any fiat to be converted between each other.
 

--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -17,11 +17,11 @@
 ## Table of Contents
 * **[Introduction](#introduction)**
 * **[Data Loader Plugin Sections](#data-loader-plugin-sections)**
-  * [Binance.com Section (REST)](#binance-com-section-rest)
+  * [Binance.com Section (REST)](#binancecom-section-rest)
   * [Bitbank Section (REST)](#bitbank-section-rest)
   * [Coinbase Section (REST)](#coinbase-section-rest)
   * [Coinbase Pro Section (REST)](#coinbase-pro-section-rest)
-  * [Binance.com Supplemental Section (CSV)](#binance.com-supplemental-section-csv)
+  * [Binance.com Supplemental Section (CSV)](#binancecom-supplemental-section-csv)
   * [Bitbank Supplemental Section (CSV)](#bitbank-supplemental-section-csv)
   * [Coincheck Supplemental Section (CSV)](#coincheck-supplemental-section-csv)
   * [Ledger Section (CSV)](#ledger-section-csv)
@@ -498,6 +498,19 @@ Be aware that:
 * The router uses the exchange listed in the transaction data to build the graph to calculate the route. If no exchange is listed, the current default is Kraken(US).
 * `fiat_priority` determines what fiat the router will attempt to route through first while trying to find a path to your quote asset.
 * Some exchanges, in particular Binance.com, might not be available in certain territories.
+
+#### A Special Note for Prices from Kraken Exchange
+Prices for the latest quarter from the Kraken exchange may be inaccurate due to the restrictions of the Kraken REST API. Only the latest 720 bars can be retrieved, so different candles must be used depending on how old the transaction is from the time you are pulling the pricing data. The following chart provides a rough estimate of what candles are used for which timeframe.
+
+transaction age    | candle used
+-------------------|-------------
+0 - 12 hours old   |          1m
+.5 - 2.5 days old  |          5m
+2.5 - 7.5 days old |         15m
+7.5 - 30 days old  |          1h
+1 - 4 months old   |          4h
+
+Accuracy will improve once new CSV data is released, which is typically 2 weeks after the end of a quarter. Also, the Kraken REST API is very slow. It may take 20-30 seconds per transaction to retrieve prices for the latest quarter.
 
 
 ### Binance Locked CCXT

--- a/mypy.ini
+++ b/mypy.ini
@@ -79,6 +79,10 @@ disallow_any_expr = False
 disallow_any_explicit = False
 disallow_any_expr = False
 
+[mypy-dali.manifest_builder]
+disallow_any_explicit = False
+disallow_any_expr = False
+
 [mypy-dali.plugin.pair_converter.historic_crypto]
 disallow_any_expr = False
 disallow_any_explicit = False

--- a/src/dali/abstract_pair_converter_plugin.py
+++ b/src/dali/abstract_pair_converter_plugin.py
@@ -120,7 +120,6 @@ class MappedGraph(Graph[ValueType]):
     # Optimized assets are tracked to prevent requesting prices for unoptimized assets
     # Negative weights will get deleted.
     def clone_with_optimization(self, optimization: Dict[str, Dict[str, float]]) -> "MappedGraph[ValueType]":
-
         cloned_mapped_graph: MappedGraph[ValueType] = MappedGraph(optimized_assets=self.__optimized_assets.copy())
 
         for original_vertex in self.vertexes:

--- a/src/dali/dali_main.py
+++ b/src/dali/dali_main.py
@@ -155,8 +155,18 @@ def _dali_main_internal(country: AbstractCountry) -> None:
             pair_converter_list.append(CcxtPairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value))
             LOGGER.info("No pair converter plugins found in configuration file: using default pair converters.")
 
+        with ThreadPool(args.thread_count) as pool:
+            result_list = pool.map(_input_plugin_helper, input_plugin_args_list)
+
+        transactions: List[AbstractTransaction] = [transaction for result in result_list for transaction in result]
+
+        LOGGER.info("Building manifest to optimize price calculation with the pair converters.")
+        manifest = TransactionManifest(transactions, args.thread_count, country.currency_iso_code.upper())
+
+        # Check if pair converter has unique cache key and optimize plugin
         pair_converters_by_cache_key: Dict[str, AbstractPairConverterPlugin] = {}
         for pair_converter in pair_converter_list:
+            pair_converter.optimize(manifest)
             cache_key = pair_converter.cache_key()
             if cache_key in pair_converters_by_cache_key:
                 LOGGER.error(
@@ -169,11 +179,6 @@ def _dali_main_internal(country: AbstractCountry) -> None:
             pair_converters_by_cache_key[cache_key] = pair_converter
 
         dali_configuration[Keyword.HISTORICAL_PAIR_CONVERTERS.value] = pair_converter_list
-
-        with ThreadPool(args.thread_count) as pool:
-            result_list = pool.map(_input_plugin_helper, input_plugin_args_list)
-
-        transactions: List[AbstractTransaction] = [transaction for result in result_list for transaction in result]
 
         LOGGER.info("Resolving transactions")
         resolved_transactions: List[AbstractTransaction] = resolve_transactions(transactions, dali_configuration, args.read_spot_price_from_web)

--- a/src/dali/dali_main.py
+++ b/src/dali/dali_main.py
@@ -51,6 +51,7 @@ from dali.plugin.pair_converter.ccxt import (
 from dali.plugin.pair_converter.historic_crypto import (
     PairConverterPlugin as HistoricCryptoPairConverterPlugin,
 )
+from dali.transaction_manifest import TransactionManifest
 from dali.transaction_resolver import resolve_transactions
 
 _VERSION: str = "0.6.9"

--- a/src/dali/plugin/pair_converter/ccxt.py
+++ b/src/dali/plugin/pair_converter/ccxt.py
@@ -440,6 +440,7 @@ class PairConverterPlugin(AbstractPairConverterPlugin):
 
         # Save the individual pair to cache
         if result is not None:
+            self.__logger.debug("Saving bar - %s for %s/%s->%s from %s", result, key.timestamp, key.from_asset, key.to_asset, key.exchange)
             self._add_bar_to_cache(key, result)
 
         return result

--- a/src/dali/plugin/pair_converter/ccxt.py
+++ b/src/dali/plugin/pair_converter/ccxt.py
@@ -253,7 +253,7 @@ class PairConverterPlugin(AbstractPairConverterPlugin):
         return self.__exchange_markets
 
     @property
-    def exchange_datetime_graph_tree_dict(self) -> Dict[str, AVLTree[datetime, MappedGraph[str]]]:
+    def exchange_2_graph_tree(self) -> Dict[str, AVLTree[datetime, MappedGraph[str]]]:
         return self.__exchange_2_graph_tree
 
     def get_historic_bar_from_native_source(self, timestamp: datetime, from_asset: str, to_asset: str, exchange: str) -> Optional[HistoricalBar]:
@@ -535,8 +535,6 @@ class PairConverterPlugin(AbstractPairConverterPlugin):
                 returned_timestamp = datetime.fromtimestamp(int(historical_data[0][0]) / _MS_IN_SECOND, timezone.utc)
                 if (returned_timestamp - timestamp).total_seconds() > _TIME_GRANULARITY_STRING_TO_SECONDS[timeframe] and not all_bars:
                     if retry_count == len(_TIME_GRANULARITY_DICT.get(exchange, _TIME_GRANULARITY)) - 1:  # If this is the last try
-                        # raise RP2ValueError(f"Internal error: Requested a spot price for {timestamp} but
-                        # got {returned_timestamp}. Graph is not optimized appropriately.")
                         self.__logger.info(
                             "For %s/%s requested candle for %s (ms %s) doesn't match the returned timestamp %s. It is assumed the asset was not tradeable at "
                             "the time of acquisition, so the first weekly candle is used for pricing. Please check the price of %s at %s.",

--- a/src/dali/plugin/pair_converter/csv/kraken.py
+++ b/src/dali/plugin/pair_converter/csv/kraken.py
@@ -69,16 +69,45 @@ _SECONDS_IN_DAY: int = 86400
 _CHUNK_SIZE: int = _SECONDS_IN_DAY * 30
 _SECONDS_IN_MINUTE: int = 60
 
-# Time in minutes
-_MINUTE: str = "1"
-_FIVE_MINUTE: str = "5"
-_FIFTEEN_MINUTE: str = "15"
-_ONE_HOUR: str = "60"
-_TWELVE_HOUR: str = "720"
-_ONE_DAY: str = "1440"
-_ONE_WEEK: str = "10080"  # Emulated
-_TIME_GRANULARITY: List[str] = [_MINUTE, _FIVE_MINUTE, _FIFTEEN_MINUTE, _ONE_HOUR, _TWELVE_HOUR, _ONE_DAY, _ONE_WEEK]
-_TIME_GRANULARITY_SET: Set[str] = set(_TIME_GRANULARITY)
+# Time in minutes, used for file names
+_MINUTE_IN_MINUTES: str = "1"
+_FIVE_MINUTE_IN_MINUTES: str = "5"
+_FIFTEEN_MINUTE_IN_MINUTES: str = "15"
+_ONE_HOUR_IN_MINUTES: str = "60"
+_TWELVE_HOUR_IN_MINUTES: str = "720"
+_ONE_DAY_IN_MINUTES: str = "1440"
+_ONE_WEEK_IN_MINUTES: str = "10080"  # Emulated
+_KRAKEN_TIME_GRANULARITY: List[str] = [
+    _MINUTE_IN_MINUTES,
+    _FIVE_MINUTE_IN_MINUTES,
+    _FIFTEEN_MINUTE_IN_MINUTES,
+    _ONE_HOUR_IN_MINUTES,
+    _TWELVE_HOUR_IN_MINUTES,
+    _ONE_DAY_IN_MINUTES,
+    _ONE_WEEK_IN_MINUTES,
+]
+
+# Time in str, which is what CCXT uses normally
+# 4 hour doesn't exist in Kraken CSV. We might need to emulate it in the future
+_MINUTE_IN_STR: str = "1m"
+_FIVE_MINUTE_IN_STR: str = "5m"
+_FIFTEEN_MINUTE_IN_STR: str = "15m"
+_ONE_HOUR_IN_STR: str = "1h"
+_TWELVE_HOUR_IN_STR: str = "12h"
+_ONE_DAY_IN_STR: str = "1d"
+_ONE_WEEK_IN_STR: str = "1w"
+_CCXT_TIME_GRANULARITY: List[str] = [
+    _MINUTE_IN_STR,
+    _FIVE_MINUTE_IN_STR,
+    _FIFTEEN_MINUTE_IN_STR,
+    _ONE_HOUR_IN_STR,
+    _TWELVE_HOUR_IN_STR,
+    _ONE_DAY_IN_STR,
+    _ONE_WEEK_IN_STR,
+]
+
+
+_CCXT_TIME_GRANULARITY_SET: Set[str] = set(_CCXT_TIME_GRANULARITY)
 
 # Chunking variables
 _PAIR_START: str = "start"
@@ -174,8 +203,9 @@ class Kraken:
             self._write_chunk_to_disk(pair, file_timestamp, duration_in_minutes, chunk)
 
             # Emulate 1 week candle
-            if duration_in_minutes == _ONE_DAY:
+            if duration_in_minutes == _ONE_DAY_IN_MINUTES:
                 week_chunk = []
+
                 for i in range(0, len(chunk), 7):
                     seven_chunks = chunk[i : i + 7]
 
@@ -184,22 +214,25 @@ class Kraken:
                         break
 
                     # The timestamp of the first row becomes the timestamp for the weekly row
-                    col_sums: List[str] = [chunk[0][self.__TIMESTAMP_INDEX]]
+                    column_sums: List[str] = [seven_chunks[0][self.__TIMESTAMP_INDEX]]
 
                     # We don't want/need to add up the timestamp column
-                    for col in range(self.__OPEN, self.__TRADES + 1):
-                        col_sum = str(sum((RP2Decimal(row[col]) for row in seven_chunks), ZERO))
+                    for column in range(self.__OPEN, self.__TRADES + 1):
+                        column_sum = str(sum((RP2Decimal(row[column]) for row in seven_chunks), ZERO))
 
                         # Average all prices
-                        if col in range(self.__OPEN, (self.__CLOSE + 1)):
-                            col_sum = str(RP2Decimal(col_sum) / RP2Decimal("7"))
-                        col_sums.append(col_sum)
-                    week_chunk.append(col_sums)
+                        # BUG FIX: shouldn't be averages but reflect a true candle (e.g. high should be the highest)
+                        if column in range(self.__OPEN, (self.__CLOSE + 1)):
+                            column_average = str(RP2Decimal(column_sum) / RP2Decimal("7"))
+                            column_sums.append(column_average)
+                        else:
+                            column_sums.append(column_sum)
+                    week_chunk.append(column_sums)
 
                 # Same file_timestamp is okay since _ONE_DAY uses _MAX_MULTIPLIER
-                self._write_chunk_to_disk(pair, file_timestamp, _ONE_WEEK, week_chunk)
+                self._write_chunk_to_disk(pair, file_timestamp, _ONE_WEEK_IN_MINUTES, week_chunk)
                 if pair_start:
-                    self.__cached_pairs[pair + _ONE_WEEK] = _PairStartEnd(start=pair_start, end=pair_end)
+                    self.__cached_pairs[pair + _ONE_WEEK_IN_MINUTES] = _PairStartEnd(start=pair_start, end=pair_end)
 
         if pair_start:
             self.__cached_pairs[pair_duration] = _PairStartEnd(start=pair_start, end=pair_end)
@@ -214,35 +247,35 @@ class Kraken:
                 csv_writer.writerow(row)
 
     def _retrieve_cached_bars(
-        self, base_asset: str, quote_asset: str, timestamp: int, all_bars: bool = False, timespan: str = _MINUTE
+        self, base_asset: str, quote_asset: str, timestamp: int, all_bars: bool = False, timespan: str = _MINUTE_IN_STR
     ) -> Optional[List[HistoricalBar]]:
         pair_name: str = base_asset + quote_asset
 
-        if timespan in _TIME_GRANULARITY_SET:
-            retry_count: int = _TIME_GRANULARITY.index(timespan)
+        if timespan in _CCXT_TIME_GRANULARITY_SET:
+            retry_count: int = _CCXT_TIME_GRANULARITY.index(timespan)
         else:
-            raise RP2ValueError("INTERNAL ERROR: Invalid timespan passed to _retrieve_cached_bars.")
+            raise RP2ValueError("Internal Error: Invalid timespan passed to _retrieve_cached_bars.")
 
-        while retry_count < len(_TIME_GRANULARITY):
-            window_start: int = self.__cached_pairs[pair_name + _TIME_GRANULARITY[retry_count]].start
-            window_end: int = self.__cached_pairs[pair_name + _TIME_GRANULARITY[retry_count]].end
+        while retry_count < len(_KRAKEN_TIME_GRANULARITY):
+            window_start: int = self.__cached_pairs[pair_name + _KRAKEN_TIME_GRANULARITY[retry_count]].start
+            window_end: int = self.__cached_pairs[pair_name + _KRAKEN_TIME_GRANULARITY[retry_count]].end
 
             if timestamp < window_start or timestamp > window_end:
                 self.__logger.debug("Out of range - %s < %s or %s > %s", timestamp, window_start, timestamp, window_end)
                 retry_count += 1
                 continue
 
-            duration_chunk_size = _CHUNK_SIZE * min(int(_TIME_GRANULARITY[retry_count]), _MAX_MULTIPLIER)
+            duration_chunk_size = _CHUNK_SIZE * min(int(_KRAKEN_TIME_GRANULARITY[retry_count]), _MAX_MULTIPLIER)
             result: List[HistoricalBar] = []
             file_timestamp: int = (timestamp // duration_chunk_size) * duration_chunk_size
 
             # Floor the timestamp to find the price
-            duration_timestamp: int = (timestamp // (int(_TIME_GRANULARITY[retry_count]) * _SECONDS_IN_MINUTE)) * (
-                int(_TIME_GRANULARITY[retry_count]) * _SECONDS_IN_MINUTE
+            duration_timestamp: int = (timestamp // (int(_KRAKEN_TIME_GRANULARITY[retry_count]) * _SECONDS_IN_MINUTE)) * (
+                int(_KRAKEN_TIME_GRANULARITY[retry_count]) * _SECONDS_IN_MINUTE
             )
 
             while file_timestamp < window_end:
-                file_name: str = f"{base_asset + quote_asset}_{file_timestamp}_{_TIME_GRANULARITY[retry_count]}.csv.gz"
+                file_name: str = f"{base_asset + quote_asset}_{file_timestamp}_{_KRAKEN_TIME_GRANULARITY[retry_count]}.csv.gz"
                 file_path: str = path.join(self.__CACHE_DIRECTORY, file_name)
                 if all_bars:
                     self.__logger.debug(
@@ -257,7 +290,7 @@ class Kraken:
                             if all_bars and int(row[self.__TIMESTAMP_INDEX]) >= duration_timestamp:
                                 result.append(
                                     HistoricalBar(
-                                        duration=timedelta(minutes=int(_TIME_GRANULARITY[retry_count])),
+                                        duration=timedelta(minutes=int(_KRAKEN_TIME_GRANULARITY[retry_count])),
                                         timestamp=datetime.fromtimestamp(int(row[self.__TIMESTAMP_INDEX]), timezone.utc),
                                         open=RP2Decimal(row[self.__OPEN]),
                                         high=RP2Decimal(row[self.__HIGH]),
@@ -269,7 +302,7 @@ class Kraken:
                             elif int(row[self.__TIMESTAMP_INDEX]) == duration_timestamp:
                                 return [
                                     HistoricalBar(
-                                        duration=timedelta(minutes=int(_TIME_GRANULARITY[retry_count])),
+                                        duration=timedelta(minutes=int(_KRAKEN_TIME_GRANULARITY[retry_count])),
                                         timestamp=datetime.fromtimestamp(int(row[self.__TIMESTAMP_INDEX]), timezone.utc),
                                         open=RP2Decimal(row[self.__OPEN]),
                                         high=RP2Decimal(row[self.__HIGH]),
@@ -298,26 +331,30 @@ class Kraken:
         return None
 
     def find_historical_bars(
-        self, base_asset: str, quote_asset: str, timestamp: datetime, all_bars: bool = False, timespan: str = _MINUTE
+        self, base_asset: str, quote_asset: str, timestamp: datetime, all_bars: bool = False, timespan: str = _MINUTE_IN_STR
     ) -> Optional[List[HistoricalBar]]:
+        # Kraken refers to BTC as XBT only on it's API
+        if base_asset == "BTC":
+            base_asset = "XBT"
         epoch_timestamp = int(timestamp.timestamp())
         self.__logger.debug("Retrieving bar for %s%s at %s", base_asset, quote_asset, epoch_timestamp)
 
         if not self.__cache_loaded:
             self.__logger.debug("Loading cache for Kraken CSV pair converter.")
             self.__load_cache()
+            self.__cache_loaded = True
 
         # Attempt to load smallest duration
-        if self.__cached_pairs.get(base_asset + quote_asset + "1"):
+        if self.__cached_pairs.get(base_asset + quote_asset + _MINUTE_IN_MINUTES):
             self.__logger.debug("Retrieving cached bar for %s, %s at %s", base_asset, quote_asset, epoch_timestamp)
             return self._retrieve_cached_bars(base_asset, quote_asset, epoch_timestamp, all_bars, timespan)
 
-        if self._download_and_chunk(base_asset, quote_asset):
+        if self._download_and_chunk(base_asset, quote_asset, all_bars):
             return self._retrieve_cached_bars(base_asset, quote_asset, epoch_timestamp, all_bars, timespan)
 
         return None
 
-    def _download_and_chunk(self, base_asset: str, quote_asset: str) -> bool:
+    def _download_and_chunk(self, base_asset: str, quote_asset: str, all_bars: bool = False) -> bool:
         base_file: str = f"{base_asset}_OHLCVT.zip"
 
         self.__logger.info("Attempting to load %s from Kraken Google Drive.", base_file)
@@ -326,7 +363,11 @@ class Kraken:
         if file_bytes:
             with ZipFile(BytesIO(file_bytes)) as zipped_ohlcvt:
                 self.__logger.debug("Files found in zipped file - %s", zipped_ohlcvt.namelist())
-                all_timespans_for_pair: List[str] = [x for x in zipped_ohlcvt.namelist() if x.startswith(f"{base_asset}{quote_asset}_")]
+                all_timespans_for_pair: List[str]
+                if all_bars:
+                    all_timespans_for_pair = zipped_ohlcvt.namelist()
+                else:
+                    all_timespans_for_pair = [x for x in zipped_ohlcvt.namelist() if x.startswith(f"{base_asset}{quote_asset}_")]
                 if len(all_timespans_for_pair) == 0:
                     self.__logger.debug("Market not found in Kraken files. Skipping file read.")
                     return False
@@ -443,11 +484,19 @@ class Kraken:
                 return None
 
             self.__logger.debug("Retrieved %s from %s", data, response.url)
+            retry_count: int = 0
 
-            # Downloading the zipfile that contains the 6 files one for each of the standard durations of candles:
-            # 1m, 5m, 15m, 1h, 12h, 24h.
-            params = {_ALT: _MEDIA, _API_KEY: self.__google_api_key, _CONFIRM: 1}  # _CONFIRM: 1 bypasses large file warning
-            file_response: Response = self.__session.get(f"{_GOOGLE_APIS_URL}/{data[_FILES][0][_ID]}", params=params, timeout=self.__TIMEOUT)
+            while True:
+                # Downloading the zipfile that contains the 6 files one for each of the standard durations of candles:
+                # 1m, 5m, 15m, 1h, 12h, 24h.
+                params = {_ALT: _MEDIA, _API_KEY: self.__google_api_key, _CONFIRM: 1}  # _CONFIRM: 1 bypasses large file warning
+                file_response: Response = self.__session.get(f"{_GOOGLE_APIS_URL}/{data[_FILES][0][_ID]}", params=params, timeout=self.__TIMEOUT)
+                with ZipFile(BytesIO(file_response.content)) as file_check:
+                    if file_check.testzip() is None:
+                        break
+                    retry_count += 1
+                if retry_count > 2:
+                    raise RP2RuntimeError(f"Invalid zipfile - {file_name}. Giving up. Try again later.")
 
         except JSONDecodeError as exc:
             self.__logger.debug("Fetching of kraken csv files failed. Try again later.")

--- a/src/dali/plugin/pair_converter/csv/kraken.py
+++ b/src/dali/plugin/pair_converter/csv/kraken.py
@@ -169,18 +169,21 @@ class Kraken:
             elif position == _PAIR_START:
                 pair_start = int(chunk[0][self.__TIMESTAMP_INDEX])
 
-            chunk_filename: str = f'{pair}_{file_timestamp}_{duration_in_minutes}.{"csv.gz"}'
-            chunk_filepath: str = path.join(self.__CACHE_DIRECTORY, chunk_filename)
+            self._write_chunk_to_disk(pair, file_timestamp, duration_in_minutes, chunk)
 
-            with gopen(chunk_filepath, "wt", encoding="utf-8", newline="") as chunk_file:
-                csv_writer = writer(chunk_file)
-                for row in chunk:
-                    csv_writer.writerow(row)
 
         if pair_start:
             self.__cached_pairs[pair_duration] = _PairStartEnd(start=pair_start, end=pair_end)
 
     def _retrieve_cached_bar(self, base_asset: str, quote_asset: str, timestamp: int) -> Optional[HistoricalBar]:
+    def _write_chunk_to_disk(self, pair: str, file_timestamp: str, duration_in_minutes: str, chunk: List[List[str]]) -> None:
+        chunk_filename: str = f'{pair}_{file_timestamp}_{duration_in_minutes}.{"csv.gz"}'
+        chunk_filepath: str = path.join(self.__CACHE_DIRECTORY, chunk_filename)
+
+        with gopen(chunk_filepath, "wt", encoding="utf-8", newline="") as chunk_file:
+            csv_writer = writer(chunk_file)
+            for row in chunk:
+                csv_writer.writerow(row)
         pair_name: str = base_asset + quote_asset
 
         retry_count: int = 0

--- a/src/dali/plugin/pair_converter/historic_crypto.py
+++ b/src/dali/plugin/pair_converter/historic_crypto.py
@@ -19,7 +19,6 @@ from Historic_Crypto import HistoricalData
 from rp2.rp2_decimal import RP2Decimal
 
 from dali.abstract_pair_converter_plugin import AbstractPairConverterPlugin
-
 from dali.historical_bar import HistoricalBar
 from dali.transaction_manifest import TransactionManifest
 

--- a/src/dali/plugin/pair_converter/historic_crypto.py
+++ b/src/dali/plugin/pair_converter/historic_crypto.py
@@ -19,6 +19,7 @@ from Historic_Crypto import HistoricalData
 from rp2.rp2_decimal import RP2Decimal
 
 from dali.abstract_pair_converter_plugin import AbstractPairConverterPlugin
+
 from dali.historical_bar import HistoricalBar
 from dali.transaction_manifest import TransactionManifest
 
@@ -29,6 +30,9 @@ class PairConverterPlugin(AbstractPairConverterPlugin):
 
     def cache_key(self) -> str:
         return self.name()
+
+    def optimize(self, transaction_manifest: TransactionManifest) -> None:
+        pass
 
     def get_historic_bar_from_native_source(self, timestamp: datetime, from_asset: str, to_asset: str, exchange: str) -> Optional[HistoricalBar]:
         result: Optional[HistoricalBar] = None

--- a/src/dali/plugin/pair_converter/historic_crypto.py
+++ b/src/dali/plugin/pair_converter/historic_crypto.py
@@ -20,6 +20,7 @@ from rp2.rp2_decimal import RP2Decimal
 
 from dali.abstract_pair_converter_plugin import AbstractPairConverterPlugin
 from dali.historical_bar import HistoricalBar
+from dali.transaction_manifest import TransactionManifest
 
 
 class PairConverterPlugin(AbstractPairConverterPlugin):

--- a/src/dali/transaction_manifest.py
+++ b/src/dali/transaction_manifest.py
@@ -1,0 +1,85 @@
+# Copyright 2023 Neal Chambers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timezone
+from multiprocessing.pool import ThreadPool
+from typing import List, Set, Tuple
+
+from rp2.rp2_error import RP2TypeError
+
+from dali.abstract_transaction import AbstractTransaction
+from dali.in_transaction import InTransaction
+from dali.intra_transaction import IntraTransaction
+from dali.logger import LOGGER
+from dali.out_transaction import OutTransaction
+
+
+# The TransactionManifest helps pair_converter plugins optimize their searches for prices from the web
+# by informing the plugin of what assets and exchanges will need pricing as well as the first transaction datetime
+class TransactionManifest:
+    def __init__(self, transactions: List[AbstractTransaction], threads: int, native_fiat: str):
+        # Split the transactions into chunks
+        chunk_size = len(transactions) // threads
+        chunks = [transactions[i : i + chunk_size] for i in range(0, len(transactions), chunk_size)]
+
+        with ThreadPool(threads) as pool:
+            result_list = pool.map(self._process_chunk, chunks)
+
+        # Combine the asset and exchange sets
+        combined_assets = {native_fiat}
+        combined_exchanges = set()
+        first_transaction_datetime = datetime.now(timezone.utc)
+
+        for result in result_list:
+            combined_assets.update(result[1])
+            combined_exchanges.update(result[2])
+            if result[0] < first_transaction_datetime:
+                first_transaction_datetime = result[0]
+
+        self.__assets: Set[str] = combined_assets
+        self.__exchanges: Set[str] = combined_exchanges
+        self.__first_transaction_datetime: datetime = first_transaction_datetime
+        LOGGER.debug(
+            "Created manifest - Assets: %s, Exchanges: %s, and first transaction: %s", self.__assets, self.__exchanges, self.__first_transaction_datetime
+        )
+
+    @property
+    def assets(self) -> Set[str]:
+        return self.__assets
+
+    @property
+    def exchanges(self) -> Set[str]:
+        return self.__exchanges
+
+    @property
+    def first_transaction_datetime(self) -> datetime:
+        return self.__first_transaction_datetime
+
+    def _process_chunk(self, transactions: List[AbstractTransaction]) -> Tuple[datetime, Set[str], Set[str]]:
+        first_transaction_datetime: datetime = datetime.now(timezone.utc)
+        assets: Set[str] = set()
+        exchanges: Set[str] = set()
+
+        for transaction in transactions:
+            assets.add(transaction.asset)
+            if transaction.timestamp_value < first_transaction_datetime:
+                first_transaction_datetime = transaction.timestamp_value
+            elif isinstance(transaction, (InTransaction, OutTransaction)):
+                exchanges.add(transaction.exchange)
+            elif isinstance(transaction, IntraTransaction):
+                exchanges.add(transaction.from_exchange)
+            else:
+                raise RP2TypeError("Internal error: Invalid transaction type passed to _process_chunk.")
+
+        return first_transaction_datetime, assets, exchanges

--- a/src/stubs/ccxt.pyi
+++ b/src/stubs/ccxt.pyi
@@ -59,15 +59,15 @@ class bitbank(Exchange):
     def __init__(self, config: Dict[str, Union[str, bool]]) -> None: ...
     options: Dict[str, str]
 
+class bitfinex(Exchange):
+    def __init__(self, config: Dict[str, Union[str, bool]]) -> None: ...
+    options: Dict[str, str]
+
 class coinbase(Exchange):
     def __init__(self, config: Dict[str, Union[str, bool]]) -> None: ...
     options: Dict[str, str]
 
 class coinbasepro(Exchange):
-    def __init__(self, config: Dict[str, Union[str, bool]]) -> None: ...
-    options: Dict[str, str]
-
-class ftx(Exchange):
     def __init__(self, config: Dict[str, Union[str, bool]]) -> None: ...
     options: Dict[str, str]
 

--- a/tests/test_abstract_pair_converter.py
+++ b/tests/test_abstract_pair_converter.py
@@ -14,12 +14,27 @@
 
 from typing import Optional
 
+import pytest
 from prezzemolo.vertex import Vertex
+from rp2.rp2_error import RP2ValueError
 
 from dali.abstract_pair_converter_plugin import MappedGraph
 
 
 class TestAbstractPairConverterPlugin:
+    @pytest.fixture
+    def cloneable_graph(self) -> MappedGraph[str]:
+        current_graph: MappedGraph[str] = MappedGraph[str]()
+
+        current_graph.add_missing_vertex("BTC")
+        current_graph.add_missing_vertex("ETH")
+        current_graph.add_neighbor("ETH", "USD", 1.0)
+        current_graph.add_neighbor("ETH", "USDT", 2.0)
+        current_graph.add_neighbor("BTC", "USD", 1.0)
+        current_graph.add_neighbor("BTC", "USDT", 2.0)
+
+        return current_graph
+
     def test_mapped_graph_class(self) -> None:
         current_graph: MappedGraph[str] = MappedGraph[str]()
 
@@ -38,3 +53,44 @@ class TestAbstractPairConverterPlugin:
         assert first_vertex_in_graph
         assert second_vertex_in_graph
         assert first_vertex_in_graph.has_neighbor(second_vertex_in_graph)
+
+    def test_mapped_graph_cloning_changing_weights(self, cloneable_graph: MappedGraph[str]) -> None:
+        cloned_graph = cloneable_graph.clone_with_optimization("ETH", {"USD": 3.0})
+
+        assert cloned_graph.is_optimized("ETH")
+        assert not cloned_graph.is_optimized("BTC")
+        assert cloned_graph.get_vertex("ETH").get_weight(cloned_graph.get_vertex("USD")) == 3.0  # type: ignore
+        assert cloned_graph.get_vertex("ETH").get_weight(cloned_graph.get_vertex("USDT")) == 2.0  # type: ignore
+        assert cloned_graph.get_vertex("BTC").get_weight(cloned_graph.get_vertex("USD")) == 1.0  # type: ignore
+
+    def test_mapped_graph_clone_has_new_vertexes(self, cloneable_graph: MappedGraph[str]) -> None:
+        cloned_graph = cloneable_graph.clone_with_optimization("", {})
+        cloned_vertex = cloned_graph.get_vertex("ETH")
+
+        for vertex in cloneable_graph.vertexes:
+            assert not cloned_vertex is vertex
+
+    def test_mapped_graph_cloning_deleting_neighbor(self, cloneable_graph: MappedGraph[str]) -> None:
+        cloned_graph = cloneable_graph.clone_with_optimization("ETH", {"USD": -1.0, "USDT": 1.0})
+
+        assert cloned_graph.is_optimized("ETH")
+        assert not cloned_graph.is_optimized("BTC")
+        assert not cloned_graph.get_vertex("ETH").has_neighbor(cloned_graph.get_vertex("USD"))  # type: ignore
+        assert cloned_graph.get_vertex("BTC").has_neighbor(cloned_graph.get_vertex("USD"))  # type: ignore
+
+    def test_mapped_graph_cloning_adding_neighbor(self, cloneable_graph: MappedGraph[str]) -> None:
+        cloned_graph = cloneable_graph.clone_with_optimization("ETH", {"USDC": 3.0})
+
+        assert cloned_graph.is_optimized("ETH")
+        assert not cloned_graph.is_optimized("BTC")
+        assert cloned_graph.get_vertex("ETH").has_neighbor(cloned_graph.get_vertex("USDC"))  # type: ignore
+        assert not cloned_graph.get_vertex("BTC").has_neighbor(cloned_graph.get_vertex("USDC"))  # type: ignore
+
+    def test_mapped_graph_throws_exception(self, cloneable_graph: MappedGraph[str]) -> None:
+        cloned_graph = cloneable_graph.clone_with_optimization("ETH", {"USD": 3.0})
+        with pytest.raises(RP2ValueError):
+            cloned_graph.clone_with_optimization("ETH", {"USD": 3.0})
+
+        cloned_graph2 = cloned_graph.clone_with_optimization("BTC", {"USD": 3.0})
+
+        assert cloned_graph2.get_vertex("BTC").get_weight(cloned_graph2.get_vertex("USD")) == 3.0  # type: ignore

--- a/tests/test_plugin_ccxt.py
+++ b/tests/test_plugin_ccxt.py
@@ -786,7 +786,7 @@ class TestCcxtPlugin:
         assert optimized_data.volume == BTCUSDC_VOLUME + USDCUSD_VOLUME
 
         # Testing for graph compression
-        exchange_tree: AVLTree[datetime, MappedGraph[str]] = plugin.exchange_datetime_graph_tree_dict[TEST_EXCHANGE]
+        exchange_tree: AVLTree[datetime, MappedGraph[str]] = plugin.exchange_2_graph_tree[TEST_EXCHANGE]
         assert exchange_tree._get_height(exchange_tree.root) == 2  # pylint: disable=protected-access
 
         # Testing if separate snapshot was correctly made

--- a/tests/test_plugin_ccxt.py
+++ b/tests/test_plugin_ccxt.py
@@ -14,14 +14,19 @@
 
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Generator, List, Union
 
 import pytest
 from ccxt import binance, kraken
+from prezzemolo.avl_tree import AVLTree
 from prezzemolo.vertex import Vertex
 from rp2.rp2_decimal import ZERO, RP2Decimal
 
-from dali.abstract_pair_converter_plugin import AssetPairAndTimestamp, MappedGraph
+from dali.abstract_pair_converter_plugin import (
+    AssetPairAndTimestamp,
+    MappedGraph,
+    TransactionManifest,
+)
 from dali.cache import CACHE_DIR, load_from_cache
 from dali.configuration import Keyword
 from dali.historical_bar import HistoricalBar
@@ -35,9 +40,11 @@ LOCKED_EXCHANGE: str = "Kraken"
 FIAT_EXHANGE: str = "fiat"
 TEST_MARKETS: Dict[str, List[str]] = {
     "BTCUSDT": [ALT_EXCHANGE],
+    "BTCUSDC": [ALT_EXCHANGE],
     "BTCGBP": [ALT_EXCHANGE],
     "BETHETH": [ALT_EXCHANGE],
     "ETHUSDT": [ALT_EXCHANGE],
+    "USDCUSD": [TEST_EXCHANGE],
     "USDTUSD": [TEST_EXCHANGE],
     "USDJPY": [FIAT_EXHANGE],
 }
@@ -46,14 +53,23 @@ LOCKED_MARKETS: Dict[str, List[str]] = {
     "USDTUSD": [TEST_EXCHANGE],
 }
 
+# BTCUSDC conversion
+BTCUSDC_DURATION: str = "1m"
+BTCUSDC_TIMESTAMP: datetime = datetime.fromtimestamp(1504541580, timezone.utc)
+BTCUSDC_LOW: RP2Decimal = RP2Decimal("5230.0")
+BTCUSDC_HIGH: RP2Decimal = RP2Decimal("5240.6")
+BTCUSDC_OPEN: RP2Decimal = RP2Decimal("5235.4")
+BTCUSDC_CLOSE: RP2Decimal = RP2Decimal("5230.7")
+BTCUSDC_VOLUME: RP2Decimal = RP2Decimal("137.72941911")
+
 # BTCUSDT conversion
-BAR_DURATION: str = "1m"
-BAR_TIMESTAMP: datetime = datetime.fromtimestamp(1504541580, timezone.utc)
-BAR_LOW: RP2Decimal = RP2Decimal("4230.0")
-BAR_HIGH: RP2Decimal = RP2Decimal("4240.6")
-BAR_OPEN: RP2Decimal = RP2Decimal("4235.4")
-BAR_CLOSE: RP2Decimal = RP2Decimal("4230.7")
-BAR_VOLUME: RP2Decimal = RP2Decimal("37.72941911")
+BTCUSDT_DURATION: str = "1m"
+BTCUSDT_TIMESTAMP: datetime = datetime.fromtimestamp(1504541580, timezone.utc)
+BTCUSDT_LOW: RP2Decimal = RP2Decimal("4230.0")
+BTCUSDT_HIGH: RP2Decimal = RP2Decimal("4240.6")
+BTCUSDT_OPEN: RP2Decimal = RP2Decimal("4235.4")
+BTCUSDT_CLOSE: RP2Decimal = RP2Decimal("4230.7")
+BTCUSDT_VOLUME: RP2Decimal = RP2Decimal("37.72941911")
 
 # USDTUSD conversion
 USDTUSD_DURATION: str = "1m"
@@ -63,6 +79,15 @@ USDTUSD_HIGH: RP2Decimal = RP2Decimal("0.9988")
 USDTUSD_OPEN: RP2Decimal = RP2Decimal("0.9987")
 USDTUSD_CLOSE: RP2Decimal = RP2Decimal("0.9988")
 USDTUSD_VOLUME: RP2Decimal = RP2Decimal("113.786789")
+
+# USDCUSD conversion
+USDCUSD_DURATION: str = "1m"
+USDCUSD_TIMESTAMP: datetime = datetime.fromtimestamp(1504541580, timezone.utc)
+USDCUSD_LOW: RP2Decimal = RP2Decimal("1.9987")
+USDCUSD_HIGH: RP2Decimal = RP2Decimal("1.9988")
+USDCUSD_OPEN: RP2Decimal = RP2Decimal("1.9987")
+USDCUSD_CLOSE: RP2Decimal = RP2Decimal("1.9988")
+USDCUSD_VOLUME: RP2Decimal = RP2Decimal("213.786789")
 
 # Missing Fiat Test
 JPY_USD_RATE: RP2Decimal = RP2Decimal("115")
@@ -82,7 +107,7 @@ ETHUSDT_CLOSE: RP2Decimal = RP2Decimal("1763.03")
 ETHUSDT_VOLUME: RP2Decimal = RP2Decimal("434")
 
 # Non-USD Fiat pair conversion
-BTCGBP_TIMESTAMP: datetime = datetime.fromtimestamp(1504541600, timezone.utc)
+BTCGBP_TIMESTAMP: datetime = datetime.fromtimestamp(1504541580, timezone.utc)
 BTCGBP_LOW: RP2Decimal = RP2Decimal("3379.06")
 BTCGBP_HIGH: RP2Decimal = RP2Decimal("3387.53")
 BTCGBP_OPEN: RP2Decimal = RP2Decimal("3383.29")
@@ -103,28 +128,78 @@ KRAKEN_VOLUME: RP2Decimal = RP2Decimal("15.15")
 
 _MS_IN_SECOND: int = 1000
 
+# Time in ms
+_MINUTE: str = "1m"
+_FIVE_MINUTE: str = "5m"
+_FIFTEEN_MINUTE: str = "15m"
+_ONE_HOUR: str = "1h"
+_FOUR_HOUR: str = "4h"
+_SIX_HOUR: str = "6h"
+_ONE_DAY: str = "1d"
+_ONE_WEEK: str = "1w"
+_TIME_GRANULARITY_STRING_TO_SECONDS: Dict[str, int] = {
+    _MINUTE: 60,
+    _FIVE_MINUTE: 300,
+    _FIFTEEN_MINUTE: 900,
+    _ONE_HOUR: 3600,
+    _FOUR_HOUR: 14400,
+    _SIX_HOUR: 21600,
+    _ONE_DAY: 86400,
+    _ONE_WEEK: 604800,
+}
+
+# Faked Volume
+LOW_VOLUME: RP2Decimal = RP2Decimal("1")
+HIGH_VOLUME: RP2Decimal = RP2Decimal("100")
+
+# Manifests
+FIRST_TRANSACTION_EPOCH: int = 1504541580
+NO_ASSET_MANIFEST: TransactionManifest = TransactionManifest(
+    assets=set(), exchanges=set(), first_transaction_datetime=datetime.fromtimestamp(FIRST_TRANSACTION_EPOCH, timezone.utc)
+)
+
 
 class TestCcxtPlugin:
     @pytest.fixture
-    def test_graph(self) -> MappedGraph[str]:
+    def test_vertex_list(self) -> List[Vertex[str]]:
         beth: Vertex[str] = Vertex[str](name="BETH")
         btc: Vertex[str] = Vertex[str](name="BTC")
         eth: Vertex[str] = Vertex[str](name="ETH")
         gbp: Vertex[str] = Vertex[str](name="GBP")
         jpy: Vertex[str] = Vertex[str](name="JPY")
+        usdc: Vertex[str] = Vertex[str](name="USDC")
         usdt: Vertex[str] = Vertex[str](name="USDT")
         usd: Vertex[str] = Vertex[str](name="USD")
 
         beth.add_neighbor(eth, 1.0)
+        btc.add_neighbor(usdc, 2.0)  # Has higher volume, but we don't want to disrupt other tests
         btc.add_neighbor(usdt, 1.0)
-        btc.add_neighbor(gbp, 1.0)
+        btc.add_neighbor(gbp, 2.0)
         eth.add_neighbor(usdt, 1.0)
+        usdc.add_neighbor(usd, 2.0)
         usdt.add_neighbor(usd, 1.0)
-        usd.add_neighbor(jpy, 2.0)
+        usd.add_neighbor(jpy, 50.0)
 
-        return MappedGraph[str]([beth, btc, eth, gbp, jpy, usdt, usd])
+        return [beth, btc, eth, gbp, jpy, usdc, usdt, usd]
 
-    def __btcusdt_mock(self, plugin: PairConverterPlugin, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    @pytest.fixture
+    def test_graph_optimized(self, test_vertex_list: List[Vertex[str]]) -> MappedGraph[str]:
+        return MappedGraph[str](test_vertex_list, {"BETH", "BTC", "ETH", "GBP", "JPY", "USDC", "USDT", "USD"})
+
+    @pytest.fixture
+    def test_graph_fiat_optimized(self, test_vertex_list: List[Vertex[str]]) -> MappedGraph[str]:
+        return MappedGraph[str](test_vertex_list, {"GBP", "JPY", "USD"})
+
+    @pytest.fixture
+    def test_tree(self, test_graph_optimized: MappedGraph[str]) -> AVLTree[datetime, MappedGraph[str]]:
+        test_tree: AVLTree[datetime, MappedGraph[str]] = AVLTree()
+
+        # The original unoptimized graph is placed at the earliest possible time
+        test_tree.insert_node(datetime.fromtimestamp(1504541580, timezone.utc), test_graph_optimized)
+
+        return test_tree
+
+    def __btcusdt_mock(self, plugin: PairConverterPlugin, mocker: Any, test_graph_optimized: MappedGraph[str]) -> None:
         exchange = kraken(
             {
                 "apiKey": "key",
@@ -141,40 +216,189 @@ class TestCcxtPlugin:
         kraken_csv = KrakenCsvPricing(google_api_key="whatever")
 
         mocker.patch.object(plugin, "_PairConverterPlugin__exchange_markets", {TEST_EXCHANGE: TEST_MARKETS})
-        mocker.patch.object(kraken_csv, "find_historical_bar", [])
-        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_csv_reader", {"kraken": kraken_csv})
-        mocker.patch.object(alt_exchange, "fetchOHLCV").return_value = [
-            [
-                BAR_TIMESTAMP,  # UTC timestamp in milliseconds, integer
-                BAR_OPEN,  # (O)pen price, float
-                BAR_HIGH,  # (H)ighest price, float
-                BAR_LOW,  # (L)owest price, float
-                BAR_CLOSE,  # (C)losing price, float
-                BAR_VOLUME,  # (V)olume (in terms of the base currency), float
-            ],
-        ]
+        mocker.patch.object(kraken_csv, "find_historical_bars").return_value = [None]
+        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_csv_reader", {"Kraken": kraken_csv})
+        mocker.patch.object(plugin, "_get_request_delay").return_value = 0.0
 
-        mocker.patch.object(exchange, "fetchOHLCV").return_value = [
-            [
-                USDTUSD_TIMESTAMP,  # UTC timestamp in milliseconds, integer
-                USDTUSD_OPEN,  # (O)pen price, float
-                USDTUSD_HIGH,  # (H)ighest price, float
-                USDTUSD_LOW,  # (L)owest price, float
-                USDTUSD_CLOSE,  # (C)losing price, float
-                USDTUSD_VOLUME,  # (V)olume (in terms of the base currency), float
-            ],
-        ]
+        def ohlcv_generator(
+            symbol_bar: List[Union[float, int]],
+            progression: List[float],
+            timeframe: str,
+        ) -> Generator[List[List[Union[float, int]]], None, None]:
+            count = 0
+            while count < len(progression):
+                yield [
+                    [
+                        symbol_bar[0] + _TIME_GRANULARITY_STRING_TO_SECONDS[timeframe] * _MS_IN_SECOND * count,  # UTC timestamp in milliseconds, integer
+                        symbol_bar[1] + progression[count],  # (O)pen price, float
+                        symbol_bar[2] + progression[count],  # (H)ighest price, float
+                        symbol_bar[3] + progression[count],  # (L)owest price, float
+                        symbol_bar[4] + progression[count],  # (C)losing price, float
+                        symbol_bar[5] + progression[count],  # (V)olume (in terms of the base currency), float
+                    ],
+                ]
+                count += 1
+
+        alt_symbol_generators: Dict[str, Generator[List[List[Union[float, int]]], None, None]] = {
+            "BTC/USDT1w": ohlcv_generator(
+                symbol_bar=[
+                    BTCUSDT_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(BTCUSDT_OPEN),  # (O)pen price, float
+                    float(BTCUSDT_HIGH),  # (H)ighest price, float
+                    float(BTCUSDT_LOW),  # (L)owest price, float
+                    float(BTCUSDT_CLOSE),  # (C)losing price, float
+                    float(BTCUSDT_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, 0, 0],
+                timeframe="1w",
+            ),
+            "BTC/USDT1m": ohlcv_generator(
+                symbol_bar=[
+                    BTCUSDT_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(BTCUSDT_OPEN),  # (O)pen price, float
+                    float(BTCUSDT_HIGH),  # (H)ighest price, float
+                    float(BTCUSDT_LOW),  # (L)owest price, float
+                    float(BTCUSDT_CLOSE),  # (C)losing price, float
+                    float(BTCUSDT_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, 0, 0],
+                timeframe="1m",
+            ),
+            "BTC/USDC1w": ohlcv_generator(
+                symbol_bar=[
+                    BTCUSDC_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(BTCUSDC_OPEN),  # (O)pen price, float
+                    float(BTCUSDC_HIGH),  # (H)ighest price, float
+                    float(BTCUSDC_LOW),  # (L)owest price, float
+                    float(BTCUSDC_CLOSE),  # (C)losing price, float
+                    float(BTCUSDC_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, -110, 0],
+                timeframe="1w",
+            ),
+            "BTC/USDC1m": ohlcv_generator(
+                symbol_bar=[
+                    BTCUSDC_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(BTCUSDC_OPEN),  # (O)pen price, float
+                    float(BTCUSDC_HIGH),  # (H)ighest price, float
+                    float(BTCUSDC_LOW),  # (L)owest price, float
+                    float(BTCUSDC_CLOSE),  # (C)losing price, float
+                    float(BTCUSDC_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, 0, 0],
+                timeframe="1m",
+            ),
+            "BTC/GBP1w": ohlcv_generator(
+                symbol_bar=[
+                    BTCGBP_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(BTCGBP_OPEN),  # (O)pen price, float
+                    float(BTCGBP_HIGH),  # (H)ighest price, float
+                    float(BTCGBP_LOW),  # (L)owest price, float
+                    float(BTCGBP_CLOSE),  # (C)losing price, float
+                    float(BTCGBP_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, 0, 0],
+                timeframe="1w",
+            ),
+            "BTC/GBP1m": ohlcv_generator(
+                symbol_bar=[
+                    BTCGBP_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(BTCGBP_OPEN),  # (O)pen price, float
+                    float(BTCGBP_HIGH),  # (H)ighest price, float
+                    float(BTCGBP_LOW),  # (L)owest price, float
+                    float(BTCGBP_CLOSE),  # (C)losing price, float
+                    float(BTCGBP_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, 0, 0],
+                timeframe="1m",
+            ),
+        }
+
+        # Mock two different markets for BTC for optimization tests
+        def fetch_ohlcv(
+            symbol: str, timeframe: str, symbol_generators: Dict[str, Generator[List[List[Union[float, int]]], None, None]]
+        ) -> List[List[Union[float, int]]]:
+            try:
+                return next(symbol_generators[symbol + timeframe])
+            except StopIteration:
+                return []
+
+        mocker.patch.object(alt_exchange, "fetchOHLCV").side_effect = lambda symbol, timeframe, timestamp, candles: fetch_ohlcv(
+            symbol, timeframe, symbol_generators=alt_symbol_generators
+        )
+
+        symbol_generators: Dict[str, Generator[List[List[Union[float, int]]], None, None]] = {
+            "USDT/USD1w": ohlcv_generator(
+                symbol_bar=[
+                    USDTUSD_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(USDTUSD_OPEN),  # (O)pen price, float
+                    float(USDTUSD_HIGH),  # (H)ighest price, float
+                    float(USDTUSD_LOW),  # (L)owest price, float
+                    float(USDTUSD_CLOSE),  # (C)losing price, float
+                    float(USDTUSD_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, -110, 0],
+                timeframe="1w",
+            ),
+            "USDT/USD1m": ohlcv_generator(
+                symbol_bar=[
+                    USDTUSD_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(USDTUSD_OPEN),  # (O)pen price, float
+                    float(USDTUSD_HIGH),  # (H)ighest price, float
+                    float(USDTUSD_LOW),  # (L)owest price, float
+                    float(USDTUSD_CLOSE),  # (C)losing price, float
+                    float(USDTUSD_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, 0, 0],
+                timeframe="1m",
+            ),
+            "USDC/USD1w": ohlcv_generator(
+                symbol_bar=[
+                    USDCUSD_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(USDCUSD_OPEN),  # (O)pen price, float
+                    float(USDCUSD_HIGH),  # (H)ighest price, float
+                    float(USDCUSD_LOW),  # (L)owest price, float
+                    float(USDCUSD_CLOSE),  # (C)losing price, float
+                    float(USDCUSD_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, -110, 0],
+                timeframe="1w",
+            ),
+            "USDC/USD1m": ohlcv_generator(
+                symbol_bar=[
+                    USDCUSD_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                    float(USDCUSD_OPEN),  # (O)pen price, float
+                    float(USDCUSD_HIGH),  # (H)ighest price, float
+                    float(USDCUSD_LOW),  # (L)owest price, float
+                    float(USDCUSD_CLOSE),  # (C)losing price, float
+                    float(USDCUSD_VOLUME),  # (V)olume (in terms of the base currency), float
+                ],
+                progression=[0, 0, 0, 0],
+                timeframe="1m",
+            ),
+        }
+
+        mocker.patch.object(exchange, "fetchOHLCV").side_effect = lambda symbol, timeframe, timestamp, candles: fetch_ohlcv(
+            symbol, timeframe, symbol_generators=symbol_generators
+        )
         mocker.patch.object(plugin, "_PairConverterPlugin__exchanges", {TEST_EXCHANGE: exchange, ALT_EXCHANGE: alt_exchange})
-        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_graphs", {TEST_EXCHANGE: test_graph})
+        mocker.patch.object(plugin, "_generate_unoptimized_graph").return_value = test_graph_optimized
 
-    def test_unknown_exchange(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def __btcusdt_mock_unoptimized(
+        self, plugin: PairConverterPlugin, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]
+    ) -> None:
+        self.__btcusdt_mock(plugin, mocker, test_graph_optimized)
+
+        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_datetime_graph_tree_dict", {TEST_EXCHANGE: test_tree})
+
+    def test_unknown_exchange(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
-        self.__btcusdt_mock(plugin, mocker, test_graph)
+        self.__btcusdt_mock_unoptimized(plugin, mocker, test_graph_optimized, test_tree)
 
-        data = plugin.get_historic_bar_from_native_source(BAR_TIMESTAMP, "BTC", "USD", "Bogus Exchange")
+        data = plugin.get_historic_bar_from_native_source(BTCUSDT_TIMESTAMP, "BTC", "USD", "Bogus Exchange")
         assert data
 
-    def test_historical_prices(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def test_historical_prices(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
         cache_path = os.path.join(CACHE_DIR, plugin.cache_key())
         if os.path.exists(cache_path):
@@ -182,29 +406,29 @@ class TestCcxtPlugin:
 
         # Reinstantiate plugin now that cache is gone
         plugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
-        self.__btcusdt_mock(plugin, mocker, test_graph)
+        self.__btcusdt_mock_unoptimized(plugin, mocker, test_graph_optimized, test_tree)
 
-        data = plugin.get_historic_bar_from_native_source(BAR_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
+        data = plugin.get_historic_bar_from_native_source(BTCUSDT_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
 
         assert data
-        assert data.timestamp == BAR_TIMESTAMP
-        assert data.low == BAR_LOW * USDTUSD_LOW
-        assert data.high == BAR_HIGH * USDTUSD_HIGH
-        assert data.open == BAR_OPEN * USDTUSD_OPEN
-        assert data.close == BAR_CLOSE * USDTUSD_CLOSE
-        assert data.volume == BAR_VOLUME + USDTUSD_VOLUME
+        assert data.timestamp == BTCUSDT_TIMESTAMP
+        assert data.low == BTCUSDT_LOW * USDTUSD_LOW
+        assert data.high == BTCUSDT_HIGH * USDTUSD_HIGH
+        assert data.open == BTCUSDT_OPEN * USDTUSD_OPEN
+        assert data.close == BTCUSDT_CLOSE * USDTUSD_CLOSE
+        assert data.volume == BTCUSDT_VOLUME + USDTUSD_VOLUME
 
         # Read price again, but populate plugin cache this time
-        value = plugin.get_conversion_rate(BAR_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
+        value = plugin.get_conversion_rate(BTCUSDT_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
         assert value
-        assert value == BAR_HIGH * USDTUSD_HIGH
+        assert value == BTCUSDT_HIGH * USDTUSD_HIGH
 
         # Save plugin cache
         plugin.save_historical_price_cache()
 
         # Load plugin cache and verify
         cache = load_from_cache(plugin.cache_key())
-        key = AssetPairAndTimestamp(BAR_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
+        key = AssetPairAndTimestamp(BTCUSDT_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
 
         # 3 cached prices - BTC/USDT, USDT/USD, BTC/USD
         assert len(cache) == 3, str(cache)
@@ -212,13 +436,13 @@ class TestCcxtPlugin:
         data = cache[key]
 
         assert data
-        assert data.timestamp == BAR_TIMESTAMP
-        assert data.timestamp == BAR_TIMESTAMP
-        assert data.low == BAR_LOW * USDTUSD_LOW
-        assert data.high == BAR_HIGH * USDTUSD_HIGH
-        assert data.open == BAR_OPEN * USDTUSD_OPEN
-        assert data.close == BAR_CLOSE * USDTUSD_CLOSE
-        assert data.volume == BAR_VOLUME + USDTUSD_VOLUME
+        assert data.timestamp == BTCUSDT_TIMESTAMP
+        assert data.timestamp == BTCUSDT_TIMESTAMP
+        assert data.low == BTCUSDT_LOW * USDTUSD_LOW
+        assert data.high == BTCUSDT_HIGH * USDTUSD_HIGH
+        assert data.open == BTCUSDT_OPEN * USDTUSD_OPEN
+        assert data.close == BTCUSDT_CLOSE * USDTUSD_CLOSE
+        assert data.volume == BTCUSDT_VOLUME + USDTUSD_VOLUME
 
     def test_missing_historical_prices(self, mocker: Any) -> None:
         plugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
@@ -229,13 +453,13 @@ class TestCcxtPlugin:
         data = plugin.get_historic_bar_from_native_source(timestamp, "BOGUSCOIN", "JPY", TEST_EXCHANGE)
         assert data is None
 
-    def test_missing_fiat_pair(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def test_missing_fiat_pair(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
-        self.__btcusdt_mock(plugin, mocker, test_graph)
+        self.__btcusdt_mock_unoptimized(plugin, mocker, test_graph_optimized, test_tree)
 
         mocker.patch.object(plugin, "_get_fiat_exchange_rate").return_value = HistoricalBar(
             duration=timedelta(seconds=86400),
-            timestamp=BAR_TIMESTAMP,
+            timestamp=BTCUSDT_TIMESTAMP,
             open=RP2Decimal(str(JPY_USD_RATE)),
             high=RP2Decimal(str(JPY_USD_RATE)),
             low=RP2Decimal(str(JPY_USD_RATE)),
@@ -243,19 +467,19 @@ class TestCcxtPlugin:
             volume=ZERO,
         )
 
-        data = plugin.get_historic_bar_from_native_source(BAR_TIMESTAMP, "BTC", "JPY", TEST_EXCHANGE)
+        data = plugin.get_historic_bar_from_native_source(BTCUSDT_TIMESTAMP, "BTC", "JPY", TEST_EXCHANGE)
 
         assert data
-        assert data.timestamp == BAR_TIMESTAMP
-        assert data.low == BAR_LOW * USDTUSD_LOW * JPY_USD_RATE
-        assert data.high == BAR_HIGH * USDTUSD_HIGH * JPY_USD_RATE
-        assert data.open == BAR_OPEN * USDTUSD_OPEN * JPY_USD_RATE
-        assert data.close == BAR_CLOSE * USDTUSD_CLOSE * JPY_USD_RATE
-        assert data.volume == BAR_VOLUME + USDTUSD_VOLUME
+        assert data.timestamp == BTCUSDT_TIMESTAMP
+        assert data.low == BTCUSDT_LOW * USDTUSD_LOW * JPY_USD_RATE
+        assert data.high == BTCUSDT_HIGH * USDTUSD_HIGH * JPY_USD_RATE
+        assert data.open == BTCUSDT_OPEN * USDTUSD_OPEN * JPY_USD_RATE
+        assert data.close == BTCUSDT_CLOSE * USDTUSD_CLOSE * JPY_USD_RATE
+        assert data.volume == BTCUSDT_VOLUME + USDTUSD_VOLUME
 
     # Some crypto assets have no fiat or stable coin pair; they are only paired with BTC or ETH (e.g. EZ or BETH)
     # To get an accurate fiat price, we must get the price in the base asset (e.g. BETH -> ETH) then convert that to fiat (e.g. ETH -> USD)
-    def test_no_fiat_pair(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def test_no_fiat_pair(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
 
         exchange = kraken(
@@ -312,7 +536,8 @@ class TestCcxtPlugin:
             ],
         ]
         mocker.patch.object(plugin, "_PairConverterPlugin__exchanges", {TEST_EXCHANGE: exchange, ALT_EXCHANGE: alt_exchange})
-        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_graphs", {TEST_EXCHANGE: test_graph})
+        mocker.patch.object(plugin, "_generate_unoptimized_graph").return_value = test_graph_optimized
+        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_datetime_graph_tree_dict", {TEST_EXCHANGE: test_tree})
 
         data = plugin.get_historic_bar_from_native_source(BETHETH_TIMESTAMP, "BETH", "USD", TEST_EXCHANGE)
 
@@ -325,7 +550,7 @@ class TestCcxtPlugin:
         assert data.volume == BETHETH_VOLUME + ETHUSDT_VOLUME + USDTUSD_VOLUME
 
     # Test to make sure the default stable coin is not used with a fiat market that does exist on the exchange
-    def test_nonusd_fiat_pair(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def test_nonusd_fiat_pair(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value, default_exchange="Binance.com")
         alt_exchange = binance(
             {
@@ -342,26 +567,27 @@ class TestCcxtPlugin:
         mocker.patch.object(plugin, "_PairConverterPlugin__exchange_markets", {TEST_EXCHANGE: TEST_MARKETS})
         mocker.patch.object(exchange, "fetchOHLCV").return_value = [
             [
-                BAR_TIMESTAMP,  # UTC timestamp in milliseconds, integer
-                BAR_OPEN,  # (O)pen price, float
-                BAR_HIGH,  # (H)ighest price, float
-                BAR_LOW,  # (L)owest price, float
-                BAR_CLOSE,  # (C)losing price, float
-                BAR_VOLUME,  # (V)olume (in terms of the base currency), float
+                BTCUSDT_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                float(BTCUSDT_OPEN),  # (O)pen price, float
+                float(BTCUSDT_HIGH),  # (H)ighest price, float
+                float(BTCUSDT_LOW),  # (L)owest price, float
+                float(BTCUSDT_CLOSE),  # (C)losing price, float
+                float(BTCUSDT_VOLUME),  # (V)olume (in terms of the base currency), float
             ],
         ]
         mocker.patch.object(alt_exchange, "fetchOHLCV").return_value = [
             [
-                BTCGBP_TIMESTAMP,  # UTC timestamp in milliseconds, integer
-                BTCGBP_OPEN,  # (O)pen price, float
-                BTCGBP_HIGH,  # (H)ighest price, float
-                BTCGBP_LOW,  # (L)owest price, float
-                BTCGBP_CLOSE,  # (C)losing price, float
-                BTCGBP_VOLUME,  # (V)olume (in terms of the base currency), float
+                BTCGBP_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                float(BTCGBP_OPEN),  # (O)pen price, float
+                float(BTCGBP_HIGH),  # (H)ighest price, float
+                float(BTCGBP_LOW),  # (L)owest price, float
+                float(BTCGBP_CLOSE),  # (C)losing price, float
+                float(BTCGBP_VOLUME),  # (V)olume (in terms of the base currency), float
             ],
         ]
         mocker.patch.object(plugin, "_PairConverterPlugin__exchanges", {TEST_EXCHANGE: exchange, ALT_EXCHANGE: alt_exchange})
-        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_graphs", {TEST_EXCHANGE: test_graph})
+        mocker.patch.object(plugin, "_generate_unoptimized_graph").return_value = test_graph_optimized
+        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_datetime_graph_tree_dict", {TEST_EXCHANGE: test_tree})
 
         data = plugin.get_historic_bar_from_native_source(BTCGBP_TIMESTAMP, "BTC", "GBP", TEST_EXCHANGE)
 
@@ -374,7 +600,7 @@ class TestCcxtPlugin:
         assert data.volume == BTCGBP_VOLUME
 
     # Plugin should hand off the handling of a fiat to fiat pair to the fiat converter
-    def test_fiat_pair(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def test_fiat_pair(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value)
         exchange = binance(
             {
@@ -385,7 +611,9 @@ class TestCcxtPlugin:
 
         # Need to be mocked to prevent logger spam
         mocker.patch.object(plugin, "_PairConverterPlugin__exchange_markets", {TEST_EXCHANGE: ["WHATEVER"]})
-        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_graphs", {TEST_EXCHANGE: test_graph})
+        mocker.patch.object(plugin, "_generate_unoptimized_graph").return_value = test_graph_optimized
+        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_datetime_graph_tree_dict", {TEST_EXCHANGE: test_tree})
+
         mocker.patch.object(plugin, "_get_fiat_exchange_rate").return_value = HistoricalBar(
             duration=timedelta(seconds=86400),
             timestamp=EUR_USD_TIMESTAMP,
@@ -407,7 +635,7 @@ class TestCcxtPlugin:
         assert data.close == EUR_USD_RATE
         assert data.volume == ZERO
 
-    def test_kraken_csv(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def test_kraken_csv(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value, google_api_key="whatever")
 
         cache_path = os.path.join(CACHE_DIR, "Test-" + plugin.cache_key())
@@ -440,39 +668,40 @@ class TestCcxtPlugin:
         mocker.patch.object(plugin, "_PairConverterPlugin__exchange_markets", {TEST_EXCHANGE: modified_markets})
         mocker.patch.object(alt_exchange, "fetchOHLCV").return_value = [
             [
-                KRAKEN_TIMESTAMP,  # Match the timestamp to assure correct price look up
-                BAR_OPEN,  # (O)pen price, float
-                BAR_HIGH,  # (H)ighest price, float
-                BAR_LOW,  # (L)owest price, float
-                BAR_CLOSE,  # (C)losing price, float
-                BAR_VOLUME,  # (V)olume (in terms of the base currency), float
+                KRAKEN_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # Match the timestamp to assure correct price look up
+                float(BTCUSDT_OPEN),  # (O)pen price, float
+                float(BTCUSDT_HIGH),  # (H)ighest price, float
+                float(BTCUSDT_LOW),  # (L)owest price, float
+                float(BTCUSDT_CLOSE),  # (C)losing price, float
+                float(BTCUSDT_VOLUME),  # (V)olume (in terms of the base currency), float
             ],
         ]
 
         mocker.patch.object(exchange, "fetchOHLCV").return_value = [
             [
-                KRAKEN_TIMESTAMP,  # UTC timestamp in milliseconds, integer
-                USDTUSD_OPEN,  # (O)pen price, float
-                USDTUSD_HIGH,  # (H)ighest price, float
-                USDTUSD_LOW,  # (L)owest price, float
-                USDTUSD_CLOSE,  # (C)losing price, float
-                USDTUSD_VOLUME,  # (V)olume (in terms of the base currency), float
+                KRAKEN_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                float(USDTUSD_OPEN),  # (O)pen price, float
+                float(USDTUSD_HIGH),  # (H)ighest price, float
+                float(USDTUSD_LOW),  # (L)owest price, float
+                float(USDTUSD_CLOSE),  # (C)losing price, float
+                float(USDTUSD_VOLUME),  # (V)olume (in terms of the base currency), float
             ],
         ]
         mocker.patch.object(plugin, "_PairConverterPlugin__exchanges", {TEST_EXCHANGE: exchange, ALT_EXCHANGE: alt_exchange})
-        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_graphs", {TEST_EXCHANGE: test_graph})
+        mocker.patch.object(plugin, "_generate_unoptimized_graph").return_value = test_graph_optimized
+        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_datetime_graph_tree_dict", {TEST_EXCHANGE: test_tree})
 
         data = plugin.get_historic_bar_from_native_source(KRAKEN_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
 
         assert data
         assert data.timestamp == KRAKEN_TIMESTAMP
-        assert data.low == BAR_LOW * KRAKEN_LOW
-        assert data.high == BAR_HIGH * KRAKEN_HIGH
-        assert data.open == BAR_OPEN * KRAKEN_OPEN
-        assert data.close == BAR_CLOSE * KRAKEN_CLOSE
-        assert data.volume == BAR_VOLUME + KRAKEN_VOLUME
+        assert data.low == BTCUSDT_LOW * KRAKEN_LOW
+        assert data.high == BTCUSDT_HIGH * KRAKEN_HIGH
+        assert data.open == BTCUSDT_OPEN * KRAKEN_OPEN
+        assert data.close == BTCUSDT_CLOSE * KRAKEN_CLOSE
+        assert data.volume == BTCUSDT_VOLUME + KRAKEN_VOLUME
 
-    def test_locked_exchange(self, mocker: Any, test_graph: MappedGraph[str]) -> None:
+    def test_locked_exchange(self, mocker: Any, test_graph_optimized: MappedGraph[str], test_tree: AVLTree[datetime, Dict[str, MappedGraph[str]]]) -> None:
         plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value, default_exchange=LOCKED_EXCHANGE, exchange_locked=True)
         # Name is changed to exchange_instance to avoid conflicts with the side effect function `add_exchange_side_effect`
         exchange_instance = kraken(
@@ -493,34 +722,76 @@ class TestCcxtPlugin:
         mocker.patch.object(plugin, "_PairConverterPlugin__exchange_csv_reader", {LOCKED_EXCHANGE: kraken_csv})
         mocker.patch.object(exchange_instance, "fetchOHLCV").return_value = [
             [
-                BAR_TIMESTAMP,  # UTC timestamp in milliseconds, integer
-                BAR_OPEN,  # (O)pen price, float
-                BAR_HIGH,  # (H)ighest price, float
-                BAR_LOW,  # (L)owest price, float
-                BAR_CLOSE,  # (C)losing price, float
-                BAR_VOLUME,  # (V)olume (in terms of the base currency), float
+                BTCUSDT_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                float(BTCUSDT_OPEN),  # (O)pen price, float
+                float(BTCUSDT_HIGH),  # (H)ighest price, float
+                float(BTCUSDT_LOW),  # (L)owest price, float
+                float(BTCUSDT_CLOSE),  # (C)losing price, float
+                float(BTCUSDT_VOLUME),  # (V)olume (in terms of the base currency), float
             ],
         ]
 
         mocker.patch.object(alt_exchange, "fetchOHLCV").return_value = [
             [
-                USDTUSD_TIMESTAMP,  # UTC timestamp in milliseconds, integer
-                USDTUSD_OPEN,  # (O)pen price, float
-                USDTUSD_HIGH,  # (H)ighest price, float
-                USDTUSD_LOW,  # (L)owest price, float
-                USDTUSD_CLOSE,  # (C)losing price, float
-                USDTUSD_VOLUME,  # (V)olume (in terms of the base currency), float
+                USDTUSD_TIMESTAMP.timestamp() * _MS_IN_SECOND,  # UTC timestamp in milliseconds, integer
+                float(USDTUSD_OPEN),  # (O)pen price, float
+                float(USDTUSD_HIGH),  # (H)ighest price, float
+                float(USDTUSD_LOW),  # (L)owest price, float
+                float(USDTUSD_CLOSE),  # (C)losing price, float
+                float(USDTUSD_VOLUME),  # (V)olume (in terms of the base currency), float
             ],
         ]
 
-        def add_exchange_side_effect(exchange: str) -> None:  # pylint: disable=unused-argument
+        def add_exchange_side_effect(exchange: str) -> MappedGraph[str]:  # pylint: disable=unused-argument
             mocker.patch.object(plugin, "_PairConverterPlugin__exchanges", {LOCKED_EXCHANGE: exchange_instance})
-            mocker.patch.object(plugin, "_PairConverterPlugin__exchange_graphs", {LOCKED_EXCHANGE: test_graph})
             mocker.patch.object(plugin, "_PairConverterPlugin__exchange_markets", {LOCKED_EXCHANGE: LOCKED_MARKETS})
 
-        mocker.patch.object(plugin, "_add_exchange_to_memcache", autospec=True).side_effect = add_exchange_side_effect
+            return test_graph_optimized
 
-        data = plugin.get_historic_bar_from_native_source(BAR_TIMESTAMP, "BTC", "USD", "not-kraken")
+        mocker.patch.object(plugin, "_cache_graph_snapshots", autospec=True).side_effect = add_exchange_side_effect
+        mocker.patch.object(plugin, "_PairConverterPlugin__exchange_datetime_graph_tree_dict", {LOCKED_EXCHANGE: test_tree})
+
+        data = plugin.get_historic_bar_from_native_source(BTCUSDT_TIMESTAMP, "BTC", "USD", "not-kraken")
 
         assert data
-        assert mocker.patch.object(plugin, "_add_exchange_to_memcache").called_once_with(LOCKED_EXCHANGE)
+        assert mocker.patch.object(plugin, "_cache_graph_snapshots").called_once_with(LOCKED_EXCHANGE)
+
+    def test_optimization_of_graph(self, mocker: Any, test_graph_fiat_optimized: MappedGraph[str]) -> None:
+        plugin: PairConverterPlugin = PairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value, google_api_key="whatever")
+
+        self.__btcusdt_mock(plugin, mocker, test_graph_fiat_optimized)
+
+        test_manifest: TransactionManifest = TransactionManifest(
+            assets={"BTC"},
+            exchanges={"Kraken"},
+            first_transaction_datetime=datetime.fromtimestamp(1504541500, timezone.utc),
+        )
+
+        plugin.optimize(test_manifest)
+
+        optimized_data = plugin.get_historic_bar_from_native_source(BTCUSDT_TIMESTAMP, "BTC", "USD", TEST_EXCHANGE)
+
+        assert optimized_data
+        assert optimized_data.timestamp == BTCUSDC_TIMESTAMP
+        assert optimized_data.low == BTCUSDC_LOW * USDCUSD_LOW
+        assert optimized_data.high == BTCUSDC_HIGH * USDCUSD_HIGH
+        assert optimized_data.open == BTCUSDC_OPEN * USDCUSD_OPEN
+        assert optimized_data.close == BTCUSDC_CLOSE * USDCUSD_CLOSE
+        assert optimized_data.volume == BTCUSDC_VOLUME + USDCUSD_VOLUME
+
+        # Testing for graph compression
+        exchange_tree: AVLTree[datetime, MappedGraph[str]] = plugin.exchange_datetime_graph_tree_dict[TEST_EXCHANGE]
+        assert exchange_tree._get_height(exchange_tree.root) == 2  # pylint: disable=protected-access
+
+        # Testing if separate snapshot was correctly made
+        second_week_timestamp: datetime = BTCUSDT_TIMESTAMP + timedelta(weeks=2)
+
+        new_snapshot = plugin.get_historic_bar_from_native_source(second_week_timestamp, "BTC", "USD", TEST_EXCHANGE)
+
+        assert new_snapshot
+        assert new_snapshot.timestamp == second_week_timestamp
+        assert new_snapshot.low == BTCUSDT_LOW * USDTUSD_LOW
+        assert new_snapshot.high == BTCUSDT_HIGH * USDTUSD_HIGH
+        assert new_snapshot.open == BTCUSDT_OPEN * USDTUSD_OPEN
+        assert new_snapshot.close == BTCUSDT_CLOSE * USDTUSD_CLOSE
+        assert new_snapshot.volume == BTCUSDT_VOLUME + USDTUSD_VOLUME

--- a/tests/test_plugin_kraken_csv_download.py
+++ b/tests/test_plugin_kraken_csv_download.py
@@ -67,7 +67,7 @@ class TestKrakenCsvDownload:
         assert test_bar
         assert test_bar.low == RP2Decimal("1.6668")
 
-        test_bars = kraken_csv.find_historical_bars("USDT", "USD", datetime.fromtimestamp(1601683200), True, "10080")
+        test_bars = kraken_csv.find_historical_bars("USDT", "USD", datetime.fromtimestamp(1601683200), True, "1w")
 
         assert test_bars
         test_bar = test_bars[0]

--- a/tests/test_plugin_kraken_csv_download.py
+++ b/tests/test_plugin_kraken_csv_download.py
@@ -58,6 +58,7 @@ class TestKrakenCsvDownload:
         assert test_bar
         assert test_bar.low == RP2Decimal("1.778")
         assert "USDTUSD_1594080000_5.csv.gz" in files
+        assert "USDTUSD_1296000000_10080.csv.gz" in files
 
         test_bar = kraken_csv.find_historical_bar("USDT", "USD", datetime.fromtimestamp(1601683300))
 
@@ -65,3 +66,13 @@ class TestKrakenCsvDownload:
         # Also that proper price was retrieved from chunked files in the cache folder
         assert test_bar
         assert test_bar.low == RP2Decimal("1.6668")
+
+        test_bars = kraken_csv.find_historical_bars("USDT", "USD", datetime.fromtimestamp(1601683200), True, "10080")
+
+        assert test_bars
+        test_bar = test_bars[0]
+
+        # Test to make sure it only emulates full weeks
+        assert len(test_bars) == 1
+        assert test_bar.low == RP2Decimal("1.952314285714285714285714286")
+        assert test_bar.volume == RP2Decimal("12016.1594")


### PR DESCRIPTION
This addresses #145 , #143 and helps clear the way to resolve #140 

This will allow markets (or edges in the Djikstra search) to be added and deleted when cloning a graph. It also allows the optimization of a graph by altering the weights of edges during the cloning.

This is **WIP**. I submitted it to get feedback on the `MappedGraph` data class before implementing it in the CCXT pair converter.

To-do:
- [x] Write tests for optimization
- [x] Modify `_add_exchange_to_memcache` to pass unoptimized graph, and rename it `_generate_unoptimized_graph`
- [x] Modify CSV reader to return weekly candles
- [x] Add function to optimize an asset's weights in `ccxt.py`
- [x] Add check for optimization before REST call for price
- [x] Add validation of bar timestamp in order to find markets that are not available
- [x] Modify cloning function to receive multiple assets
- [x] Create manifest from transactions and pass it on to the pair converter plugins if needed
- [x] Add snapshot compression to reduce excess snapshots
- [x] Clean code