### PR TITLE
Set ODS sheet size as function of number of rows in it

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -40,6 +40,7 @@ warn_unreachable = True
 warn_unused_configs = True
 warn_unused_ignores = True
 ignore_errors = False
+mypy_path = $MYPY_CONFIG_FILE_DIR/src/stubs/
 
 [mypy-dali.abstract_input_filler]
 disallow_any_decorated = False

--- a/src/dali/ods_generator.py
+++ b/src/dali/ods_generator.py
@@ -159,6 +159,12 @@ def generate_input_file(
     current_sheet: Optional[Any] = None
     current_table: Optional[str] = None
     row_index: int = 0
+
+    transaction_count_by_asset: Dict[str, int] = {}
+    for transaction in transactions:
+        working_asset = transaction.asset
+        transaction_count_by_asset[working_asset] = transaction_count_by_asset.setdefault(working_asset, 0) + 1
+
     for transaction in transactions:
         if not isinstance(transaction, AbstractTransaction):
             raise RP2RuntimeError(f"Internal error: Parameter 'transaction' is not a subclass of AbstractTransaction. {transaction}")
@@ -170,7 +176,7 @@ def generate_input_file(
                 _fill_cell(current_sheet, row_index, 0, _TABLE_END, visual_style="bold")
             current_asset = transaction.asset
             current_sheet = ezodf.Table(current_asset)
-            current_sheet.reset(size=(len(transactions) + _MIN_ROWS, _MAX_COLUMNS))
+            current_sheet.reset(size=(transaction_count_by_asset[current_asset] + _MIN_ROWS, _MAX_COLUMNS))
             output_file.sheets += current_sheet
             row_index = 0
             current_table = None

--- a/src/stubs/ezodf/__init__.pyi
+++ b/src/stubs/ezodf/__init__.pyi
@@ -1,0 +1,18 @@
+# Copyright 2023 Christopher Whelan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .document import newdoc, opendoc  # noqa
+from .table import Table
+
+__all__ = ["opendoc", "newdoc", "Table"]

--- a/src/stubs/ezodf/document.pyi
+++ b/src/stubs/ezodf/document.pyi
@@ -1,0 +1,25 @@
+# Copyright 2021 eprbell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from .sheets import Sheets
+
+class PackagedDocument:
+    sheets: Sheets
+
+    def __init__(self, name: str) -> None: ...
+
+def opendoc(filename: str) -> PackagedDocument: ...
+def newdoc(doctype: str, filename: str, template: Optional[str]) -> PackagedDocument: ...

--- a/src/stubs/ezodf/sheets.pyi
+++ b/src/stubs/ezodf/sheets.pyi
@@ -1,4 +1,4 @@
-# Copyright 2021 eprbell
+# Copyright 2023 Christopher Whelan
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Iterator
 
-class PackagedDocument:
-    def __init__(self, name: str) -> None: ...
+from .table import Table
 
-class Table:
-    def __init__(self, name: str) -> None: ...
-
-def opendoc(filename: str) -> PackagedDocument: ...
-def newdoc(doctype: str, filename: str, template: Optional[str]) -> PackagedDocument: ...
+class Sheets:
+    def __iter__(self) -> Iterator[Table]: ...
+    def __getitem__(self, key: str) -> Table: ...

--- a/src/stubs/ezodf/table.pyi
+++ b/src/stubs/ezodf/table.pyi
@@ -1,0 +1,19 @@
+# Copyright 2023 Christopher Whelan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Table:
+    name: str
+
+    def __init__(self, name: str) -> None: ...
+    def nrows(self) -> int: ...

--- a/tests/test_ods_output_diff.py
+++ b/tests/test_ods_output_diff.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from subprocess import run
 from typing import List
 
+import ezodf
 from ods_diff import ods_diff
 
 from dali.cache import CACHE_DIR
@@ -115,6 +116,16 @@ class TestODSOutputDiff(unittest.TestCase):
     #     full_golden_file_name: Path = GOLDEN_PATH / file_name
     #     diff = ods_diff(full_golden_file_name, full_output_file_name, generate_ascii_representation=True)
     #     self.assertFalse(diff, msg=diff)
+
+    def test_ods_sheet_size(self) -> None:
+        sizes = {"test_crypto_data.ods": {"BTC": 46}}
+        for basename, sheet_sizes in sizes.items():
+            filename = self.output_dir / basename
+            file: ezodf.document.PackagedDocument = ezodf.opendoc(str(filename))
+
+            for sheet in file.sheets:
+                assert sheet.name in sheet_sizes
+                assert file.sheets[sheet.name].nrows() == sheet_sizes[sheet.name]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`dali` currently outputs a large fraction of empty rows, which `rp2` then processes individually and potentially outputs a log message per empty line. Assuming `n` transactions per asset and `k` assets, the current `dali` output is `k * n + 40` rows per asset/sheet and a total of `k^2 * n + 40k` rows per document. Thus, only `1/k` rows are populated and `rp2` runtime explodes while doing useless work.

The above actually is the best case scenario, as it is even worse when the distribution of transactions per asset is unevenly distributed.

I have included a test case but it is a bit of a no-op as I did not want to touch the golden datasets and the existing code passes without this change. Please let me know if you have any suggestions on the preferred testing approach in this case.

In order to make `mypy` happy, I also updated the `ezodf` stubs.