### PR TITLE
Set unique cache keys for pair converters

### DIFF
--- a/src/dali/dali_main.py
+++ b/src/dali/dali_main.py
@@ -157,6 +157,19 @@ def _dali_main_internal(country: AbstractCountry) -> None:
             pair_converter_list.append(CcxtPairConverterPlugin(Keyword.HISTORICAL_PRICE_HIGH.value))
             LOGGER.info("No pair converter plugins found in configuration file: using default pair converters.")
 
+        pair_converters_by_cache_key: Dict[str, AbstractPairConverterPlugin] = {}
+        for pair_converter in pair_converter_list:
+            cache_key = pair_converter.cache_key()
+            if cache_key in pair_converters_by_cache_key:
+                LOGGER.error(
+                    "Internal error: the following pair converter plugins both attempt to store at %s: %s, %s",
+                    cache_key,
+                    pair_converter.name(),
+                    pair_converters_by_cache_key[cache_key].name(),
+                )
+                sys.exit(1)
+            pair_converters_by_cache_key[cache_key] = pair_converter
+
         dali_configuration[Keyword.HISTORICAL_PAIR_CONVERTERS.value] = pair_converter_list
 
         with ThreadPool(args.thread_count) as pool:

--- a/src/dali/plugin/pair_converter/ccxt.py
+++ b/src/dali/plugin/pair_converter/ccxt.py
@@ -158,6 +158,10 @@ class PairConverterPlugin(AbstractPairConverterPlugin):
         google_api_key: Optional[str] = None,
         exchange_locked: Optional[bool] = None,
     ) -> None:
+        exchange_cache_modifier = default_exchange.replace(" ", "_") if default_exchange and exchange_locked else ""
+        fiat_priority_cache_modifier = fiat_priority if fiat_priority else ""
+        self.__cache_modifier = "_".join(x for x in [exchange_cache_modifier, fiat_priority_cache_modifier] if x)
+
         super().__init__(historical_price_type=historical_price_type, fiat_priority=fiat_priority)
         self.__logger: logging.Logger = create_logger(f"{self.name()}/{historical_price_type}")
 
@@ -179,7 +183,7 @@ class PairConverterPlugin(AbstractPairConverterPlugin):
         return "CCXT-converter"
 
     def cache_key(self) -> str:
-        return self.name()
+        return self.name() + "_" + self.__cache_modifier if self.__cache_modifier else self.name()
 
     @property
     def exchanges(self) -> Dict[str, Exchange]:


### PR DESCRIPTION
Assume a user has a config using multiple `ccxt` pair converter plugins - this can be done to express an explicit fallback order:
```
[dali.plugin.pair_converter.ccxt_binance]
...

[dali.plugin.pair_converter.ccxt_kraken]
...
```
The expected behavior in this case is:
 - `dali` checks for cached result from `binance`
 - If this doesn't exist, actually query `binance`
 - If this fails, check for cached `kraken` result
 - If this fails, actually query `kraken`
 - If we actually queried a source, store it in the cache so a future iteration can exit one step sooner

The issue with the above is that both plugins have the `cache_key()` of `CCXT-converter` and the following happens instead:
 - `binance` cache is saved to `.dali_cache/CCXT-converter`
 - `kraken` cache is saved to `.dali_cache/CCXT-converter`, over-writing the `binance` result
 - On next `dali` run, `.dali_cache/CCXT-converter` is loaded as the cache for both plugins
 - As `exchange` is part of the query key, the `binance` plugin cache is populated with `kraken` results and all queries against it fail. However, all queries against `binance`  have to be repeated and the cache is effectively disabled for all but the lowest-priority `ccxt` plugin

Due to rate limiting at the source and the cache priority inversion, the above issue can significantly slow down `dali` on repeated runs and lead to almost no caching speedup.

A subtler issue can actually occur when setting `fiat_priority` if it is modified between `dali` runs: as the fiat exchange rate is applied before adding the result to the cache, any changes to `fiat_priority` will not be reflected.

The solution is to introduce a unique cache key that incorporates settings that may invalidate the cache and to require that users not have two identical pair converter plugins.

With this change, the `ccxt_binance` plugin would write to `.dali_cache/CCXT-converter_Binance.com` and `ccxt_kraken` plugin would write to `.dali_cache/CCXT-converter_Kraken` if `fiat_priority` is not set.

I'm indifferent on the format of the `cache_key` and am open to suggestions on better ones.