### PR TITLE
Add Coinbase Pro pair converter

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -34,6 +34,7 @@
 * **[Pair Converter Plugin Sections](#pair-converter-plugin-sections)**
   * [CCXT](#ccxt)
   * [Binance Locked CCXT](#binance-locked-ccxt)
+  * [Coinbase Pro Locked CCXT](#coinbase-pro-locked-ccxt)
   * [Kraken Locked CCXT](#kraken-locked-ccxt)
   * [Historic Crypto](#historic-crypto)
 * **[Builtin Sections](#builtin-sections)**
@@ -500,6 +501,28 @@ Be aware that:
 * The router only uses Binance.com and the fiat exchange rates to build the graph to calculate the route.
 * `fiat_priority` determines what fiat the router will attempt to route through first while trying to find a path to your quote asset.
 * Binance.com might not be available in certain territories.
+
+
+### Coinbase Pro Locked CCXT
+This plugin makes use of the CCXT plugin, but locks all routes to Coinbase Pro.
+
+Initialize this plugin section as follows:
+<pre>
+[dali.plugin.pair_converter.ccxt_coinbase_pro</em>]
+historical_price_type = <em>&lt;historical_price_type&gt;</em>
+fiat_priority = <em>&lt;fiat_priority&gt;</em>
+</pre>
+
+Where:
+* `<historical_price_type>` is one of `open`, `high`, `low`, `close`, `nearest`. When DaLi downloads historical market data, it captures a `bar` of data surrounding the timestamp of the transaction. Each bar has a starting timestamp, an ending timestamp, and OHLC prices. You can choose which price to select for price lookups. The open, high, low, and close prices are self-explanatory. The `nearest` price is either the open price or the close price of the bar depending on whether the transaction time is nearer the bar starting time or the bar ending time.
+* `fiat_priority` is an optional list of strings in JSON format (e.g. `["_1stpriority_", "_2ndpriority_"...]`) that ranks the priority of fiat in the routing system. If no `fiat_priority` is given, the default priority is USD, JPY, KRW, EUR, GBP, AUD, which is based on the volume of the fiat market paired with BTC (ie. BTC/USD has the highest worldwide volume, then BTC/JPY, etc.).
+
+The Kraken Locked CCXT plugin still makes use of fiat exchange rate routing. Pricing will resolve to any major fiat currency even if it doesn't have a market (ie. not used to trade with) on Coinbase Pro.
+
+Be aware that:
+* Exchange rates for fiat transactions are based on the daily rate and not minute or hourly rates.
+* The router only uses Coinbase Pro and the fiat exchange rates to build the graph to calculate the route.
+* `fiat_priority` determines what fiat the router will attempt to route through first while trying to find a path to your quote asset.
 
 
 ### Kraken Locked CCXT

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 packages = find:
 install_requires =
     backports-datetime-fromisoformat==2.0.0
-    ccxt==2.5.1
+    ccxt==3.0.79
     Historic-Crypto>=0.1.6
     jsonschema>=3.2.0
     pandas

--- a/src/dali/plugin/pair_converter/ccxt_coinbase_pro.py
+++ b/src/dali/plugin/pair_converter/ccxt_coinbase_pro.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Christopher Whelan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from dali.plugin.pair_converter.ccxt import (
+    PairConverterPlugin as CcxtPairConverterPlugin,
+)
+
+
+class PairConverterPlugin(CcxtPairConverterPlugin):
+    def __init__(
+        self,
+        historical_price_type: str,
+        fiat_priority: Optional[str] = None,
+        google_api_key: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            historical_price_type=historical_price_type,
+            default_exchange="Coinbase Pro",
+            fiat_priority=fiat_priority,
+            exchange_locked=True,
+        )


### PR DESCRIPTION
Add a new `ccxt`-based pair converter locked to `Coinbase Pro`. This requires a few changes:
 - Addition to `_EXCHANGE_DICT`
 - Override the default `_TIME_GRANULARITY` list when using `Coinbase Pro`, as it supports `6h` instead of `4h`: https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductcandles
 - Upgrade `ccxt` to the minimum version with my fix for Coinbase Pro: https://github.com/ccxt/ccxt/pull/17646