### PR TITLE
Provide progress bar when resolving transactions

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
-known_third_party = dateutil, ezodf, jsonschema, pytz, python-dateutil, requests, rp2, setuptools, yfinance
+known_third_party = dateutil, ezodf, jsonschema, progressbar2, pytz, python-dateutil, requests, rp2, setuptools, yfinance
 profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     jsonschema>=3.2.0
     pandas
     prezzemolo>=0.0.4
+    progressbar2>=4.2.0
     pyexcel-ezodf>=0.3.4
     python-dateutil>=2.8.2
     pytz>=2021.3

--- a/src/stubs/progressbar/__init__.pyi
+++ b/src/stubs/progressbar/__init__.pyi
@@ -1,0 +1,31 @@
+# Copyright 2023 Christopher Whelan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import TracebackType
+from typing import List, Optional, Type, Union
+
+from .widgets import Widgets
+
+class ProgressBar:
+    max_value: int
+
+    def __init__(self, max_value: int, widgets: Optional[List[Union[Widgets, str]]]) -> None: ...
+    def __enter__(self) -> ProgressBar: ...
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_value: Optional[BaseException], traceback: Optional[TracebackType]) -> None: ...
+    def update(self, value: int) -> None: ...
+
+class StreamWrapper:
+    def wrap_stderr(self) -> None: ...
+
+streams = StreamWrapper()

--- a/src/stubs/progressbar/widgets.pyi
+++ b/src/stubs/progressbar/widgets.pyi
@@ -1,4 +1,4 @@
-# Copyright 2022 eprbell
+# Copyright 2023 Christopher Whelan
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+class Widgets:
+    pass
 
-import logging
+class Percentage(Widgets):
+    pass
 
-from progressbar import streams
-from rp2.logger import create_logger
+class Bar(Widgets):
+    pass
 
-# Must be called before any logging setup
-streams.wrap_stderr()
+class Timer(Widgets):
+    pass
 
-LOGGER: logging.Logger = create_logger("dali")
+class AdaptiveETA(Widgets):
+    def __init__(self, samples: int) -> None: ...


### PR DESCRIPTION
Use `progressbar2` to show `dali`'s progress during transaction resolution, which can be particularly slow when fetching prices from the web.

![Screenshot from 2023-05-06 17-56-36](https://user-images.githubusercontent.com/440095/236652410-6e85af11-95f8-4108-9fc0-13da58d9bb55.png)
