### PR TITLE
Spanish support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,3 +75,4 @@ dali = py.typed, data/*.ods
 console_scripts =
     dali_us = dali.plugin.country.us:dali_entry
     dali_jp = dali.plugin.country.jp:dali_entry
+    dali_es = dali.plugin.country.es:dali_entry

--- a/src/dali/plugin/country/es.py
+++ b/src/dali/plugin/country/es.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Larision
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from rp2.plugin.country.es import ES
+
+from dali.dali_main import dali_main
+
+
+# ES-specific entry point
+def dali_entry() -> None:
+    dali_main(ES())


### PR DESCRIPTION
Here spanish support for dali. 

Problem with fiat symbol (€) in template not showing. i suppose needed country-specific template.
