### PR TITLE
Make in, out, and intra CSV files optional

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -525,7 +525,7 @@ transaction age    | candle used
 
 Accuracy will improve once new CSV data is released, which is typically 2 weeks after the end of a quarter. Also, the Kraken REST API is very slow. It may take 20-30 seconds per transaction to retrieve prices for the latest quarter.
 
-##### Note on Unified CSV File  
+##### Note on Unified CSV File
 The unified CSV file is a CSV file that contains all the candles for all the assets on the Kraken exchange. It is used to retrieve the price for the transaction if the transaction is older than the latest quarter. The plugin will prompt you to download the unified CSV file if it is needed for the transaction. You can also manually download the file from <!-- markdown-link-check-disable -->[Kraken Exchange](https://support.kraken.com/hc/en-us/articles/360047124832-Downloadable-historical-OHLCVT-Open-High-Low-Close-Volume-Trades-data)<!-- markdown-link-check-enable --> and put it in `.dali_cache/kraken/csv/`.
 
 ### Binance Locked CCXT

--- a/src/dali/plugin/input/csv/manual.py
+++ b/src/dali/plugin/input/csv/manual.py
@@ -80,16 +80,16 @@ class InputPlugin(AbstractInputPlugin):
 
     def __init__(
         self,
-        in_csv_file: str,
-        out_csv_file: str,
-        intra_csv_file: str,
+        in_csv_file: Optional[str] = None,
+        out_csv_file: Optional[str] = None,
+        intra_csv_file: Optional[str] = None,
         native_fiat: Optional[str] = None,
     ) -> None:
         super().__init__(account_holder="", native_fiat=native_fiat)
 
-        self.__in_csv_file: str = in_csv_file
-        self.__out_csv_file: str = out_csv_file
-        self.__intra_csv_file: str = intra_csv_file
+        self.__in_csv_file: Optional[str] = in_csv_file
+        self.__out_csv_file: Optional[str] = out_csv_file
+        self.__intra_csv_file: Optional[str] = intra_csv_file
 
         self.__logger: logging.Logger = create_logger(self.__MANUAL)
 

--- a/src/dali/plugin/input/csv/trezor_v2.py
+++ b/src/dali/plugin/input/csv/trezor_v2.py
@@ -90,8 +90,9 @@ class InputPlugin(AbstractInputPlugin):
                     self.__logger.warning("Possible dusting attack (fee > 0, total = 0), skipping transaction: %s", raw_data)
                     continue
                 if line[self.__AMOUNT_UNIT] in self._POSSIBLE_DUST_ATTACKERS:
-                    self.__logger.warning("Possible dusting attack (amount unit %s is suspicious), skipping transaction: %s",
-                                          line[self.__AMOUNT_UNIT], raw_data)
+                    self.__logger.warning(
+                        "Possible dusting attack (amount unit %s is suspicious), skipping transaction: %s", line[self.__AMOUNT_UNIT], raw_data
+                    )
                     continue
                 if transaction_type in {_RECV, _SENT}:
                     result.append(


### PR DESCRIPTION
Having in, out, and intra CSV files optional is helpful to new users that are using the manual CSV files for input.  They might start with one of the three and populate the rest later.  That is, they might make sure in transactions are processed successfully, then move on to out transactions.  When using an exchange as a qualifier, it is also possible there are only in transactions, as an example.  In this case, this change allows the user to use an ini file that does not have "out_csv_file = " and "intra_csv_file = " defined since there are only in transactions.