### PR TITLE
Disable Too Many Positional Arguments

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,5 +25,6 @@ disable=
     R0913, # too-many-arguments
     R0914, # too-many-local-variables
     R0915, # too-many-statements
+    R0917, # too-many-positional-arguments
 ignore-patterns=.*\.pyi$
 max-line-length=160

--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -267,7 +267,8 @@ native_fiat = <em>&lt;native_fiat&gt;</em>
 </pre>
 
 Notes:
-* The `trades_csv_file` and `transfers_csv_file` must be extracted from the .zip that is downloadable from the app. How to export transaction history is detailed [here](https://www.pionex.com/blog/how-to-export-pionex-transaction-history-statement%E3%80%90app-version%E3%80%91/).
+<!-- markdown-link-check-disable -->
+* The `trades_csv_file` and `transfers_csv_file` must be extracted from the .zip that is downloadable from the app. How to export transaction history is detailed [here](https://www.pionex.com/blog/how-to-export-pionex-transaction-history-statement%E3%80%90app-version%E3%80%91/).<!-- markdown-link-check-enable-->
 * The `for-cointracker.csv` file is used as input to the `trades_csv_file` parameter.
 * The `deposit-withdraw.csv` file is used as the input to the`transfers_csv_file` parameter.
 

--- a/src/dali/abstract_ccxt_pair_converter_plugin.py
+++ b/src/dali/abstract_ccxt_pair_converter_plugin.py
@@ -235,6 +235,7 @@ MARKET_PADDING_IN_WEEKS: int = 4
 
 DAYS_IN_WEEK: int = 7
 
+
 class AssetPairAndHistoricalPrice(NamedTuple):
     from_asset: str
     to_asset: str

--- a/src/dali/plugin/pair_converter/csv/kraken.py
+++ b/src/dali/plugin/pair_converter/csv/kraken.py
@@ -131,6 +131,7 @@ _CHUNK_SIZE_BYTES: int = 32768  # 32kb
 
 DAYS_IN_WEEK: int = 7
 
+
 class _PairStartEnd(NamedTuple):
     end: int
     start: int
@@ -306,7 +307,6 @@ class Kraken:
                         for row in adjusted_chunk[i : i + DAYS_IN_WEEK]
                         if datetime.fromtimestamp(int(row[self.__TIMESTAMP_INDEX]), timezone.utc) < following_monday
                     ]
-
 
                     # The timestamp of the first row becomes the timestamp for the weekly row
                     column_sums: List[str] = [str(int(next_monday.timestamp()))]

--- a/tests/test_plugin_ccxt.py
+++ b/tests/test_plugin_ccxt.py
@@ -103,10 +103,10 @@ class TestCcxtPlugin:
         mocker.patch.object(plugin, "_add_bar_to_cache").side_effect = plugin._add_bar_to_cache  # pylint: disable=protected-access
 
         # Friday rate is used for Saturday and Sunday since there is no trading for ECB on weekends
-        friday_data = plugin._get_fiat_exchange_rate(   # pylint: disable=protected-access
+        friday_data = plugin._get_fiat_exchange_rate(  # pylint: disable=protected-access
             datetime(2020, 12, 31, 0, 0).replace(tzinfo=timezone.utc), "EUR", "USD"
         )
-        saturday_data = plugin._get_fiat_exchange_rate( # pylint: disable=protected-access
+        saturday_data = plugin._get_fiat_exchange_rate(  # pylint: disable=protected-access
             datetime(2021, 1, 2, 0, 0).replace(tzinfo=timezone.utc), "EUR", "USD"
         )
 
@@ -129,10 +129,10 @@ class TestCcxtPlugin:
 
         # Friday rate is used for Saturday and Sunday since there is no trading for ECB on weekends
         # Check to see if plugin will retrieve Friday rate when Saturday is requested first
-        saturday_data = plugin._get_fiat_exchange_rate( # pylint: disable=protected-access
+        saturday_data = plugin._get_fiat_exchange_rate(  # pylint: disable=protected-access
             datetime(2021, 1, 2, 0, 0).replace(tzinfo=timezone.utc), "EUR", "USD"
         )
-        friday_data = plugin._get_fiat_exchange_rate(   # pylint: disable=protected-access
+        friday_data = plugin._get_fiat_exchange_rate(  # pylint: disable=protected-access
             datetime(2020, 12, 31, 0, 0).replace(tzinfo=timezone.utc), "EUR", "USD"
         )
 


### PR DESCRIPTION
## What?
Pylint wants to punish us for too many positional arguments. I don't think we need this linter.

I also ran Black to add/delete some spaces.