### PR TITLE
Remove Unnecessary Alt Market

### DIFF
--- a/src/dali/abstract_ccxt_pair_converter_plugin.py
+++ b/src/dali/abstract_ccxt_pair_converter_plugin.py
@@ -246,6 +246,9 @@ DEFAULT_FIAT_LIST: List[str] = ["AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "NZD",
 # How much padding in weeks should we add to the graph to catch airdropped or new assets that don't yet have a market
 MARKET_PADDING_IN_WEEKS: int = 4
 
+DELETABLE_VOLUME: float = -1.0
+PADDING_VOLUME: float = -2.0
+
 DAYS_IN_WEEK: int = 7
 MANY_YEARS_IN_THE_FUTURE: relativedelta = relativedelta(years=100)
 
@@ -950,7 +953,7 @@ class AbstractCcxtPairConverterPlugin(AbstractPairConverterPlugin):
                             high=bar_check[0].high,
                             low=bar_check[0].low,
                             close=bar_check[0].close,
-                            volume=bar_check[0].volume,
+                            volume=RP2Decimal(str(PADDING_VOLUME)),
                         )
                         bar_check = [no_market_padding] + bar_check
                         child_bars[child_name][neighbor.name] = bar_check
@@ -986,7 +989,7 @@ class AbstractCcxtPairConverterPlugin(AbstractPairConverterPlugin):
                         # This is meant as a sanity check to make sure we don't route a price before the market starts
                         # If we try to lookup a price before week_start_date - MARKET_PADDING_IN_WEEKS, we will get an error
                         # Unless it is an untradeable asset, in which case we will give it a price of 0.
-                        optimizations[timestamp][crypto_asset][neighbor_asset] = -1.0
+                        optimizations[timestamp][crypto_asset][neighbor_asset] = DELETABLE_VOLUME
                     else:
                         optimizations[timestamp][crypto_asset][neighbor_asset] = float(volume)
         return optimizations

--- a/src/dali/abstract_ccxt_pair_converter_plugin.py
+++ b/src/dali/abstract_ccxt_pair_converter_plugin.py
@@ -1060,7 +1060,7 @@ class AbstractCcxtPairConverterPlugin(AbstractPairConverterPlugin):
                     alternative_market = alt_markets[asset]
 
                     if already_optimized[asset] != current_neighbors and alternative_market in already_optimized[asset]:
-                        # If all the neighbors are padding, delete the asset if an alternative market exists
+                        # If all the neighbors are padding, delete the asset if an alternative market exists.
                         if all(volume == PADDING_VOLUME for _, volume in neighbors.items()):
                             self._logger.debug("Deleting Padding %s with %s", asset, neighbors.keys())
                             timestamp_assets_to_delete.setdefault(timestamp, []).append(asset)
@@ -1068,9 +1068,9 @@ class AbstractCcxtPairConverterPlugin(AbstractPairConverterPlugin):
                             deletable_market[asset] = alternative_market
                     elif asset in deletable_market and deletable_market[asset] == current_neighbors[0]:
                         self._logger.debug("Deleting alternative market for %s at %s", asset, timestamp)
-                        # Note this deletes the asset from the snapshot and all its neighbors not just the alternative market
-                        # This will work in most cases, but if the asset has multiple alternative markets, it will delete all of them
-                        # Currently there are no assets with multiple alternative markets
+                        # Note this deletes the asset from the snapshot and all its neighbors not just the alternative market.
+                        # This will work in most cases, but if the asset has multiple alternative markets, it will delete all of them.
+                        # Currently there are no assets with multiple alternative markets.
                         timestamp_assets_to_delete.setdefault(timestamp, []).append(asset)
 
     # isolated for testing

--- a/src/dali/abstract_ccxt_pair_converter_plugin.py
+++ b/src/dali/abstract_ccxt_pair_converter_plugin.py
@@ -157,6 +157,7 @@ _ALT_MARKET_EXCHANGES_DICT: Dict[str, str] = {
     "SGBUSD": _KRAKEN,
     "SOLOUSDT": _GATE,  # To be replaced with Binance or Huobi once a CSV plugin is available
     "SWEATUSDT": _GATE,
+    "TAOUSDT": _BINANCE,
     "USDTUSD": _KRAKEN,
     "XYMUSDT": _GATE,
 }
@@ -182,13 +183,14 @@ _ALT_MARKET_BY_BASE_DICT: Dict[str, str] = {
     "SGB": "USD",
     "SOLO": "USDT",
     "SWEAT": "USDT",
+    "TAO": "USDT",
     "USDT": "USD",
     "XYM": "USDT",
 }
 
 # Sometimes an indirect route (eg. BTC -> USDT -> USD) exists before a native one (eg. BTC -> USD)
 # We need to force routing in these cases.
-_FORCE_ROUTING: Set[str] = {"OPUSD"}
+_FORCE_ROUTING: Set[str] = {"OPUSD", "TAOUSD"}
 
 # Priority for quote asset. If asset is not listed it will be filtered out.
 # In principle this should be fiat in order of trade volume and then stable coins in order of trade volume


### PR DESCRIPTION
## What?

When an alternative market exists before a perfect match market (e.g. TAO->USDT exists before TAO->USD) we need to force routing through the system to use the alternative market. Once the main market becomes available we need to stop using the alternative market. Also, the padding that is automatically applied to markets before it starts trading on an exchange needs to be deleted when an alternative market exists that can provide unpadded prices.

This code looks for assets that are already optimized that are in alternative markets. If it finds that the main market comes available it will delete the padding automatically applied and use the alternative market. Once the market actually starts it will delete subsequent alternative markets so that there is no overlap. 